### PR TITLE
API Updates for v1.1-dev (upgrade path and https, 1/3)

### DIFF
--- a/APIs/NodeAPI.raml
+++ b/APIs/NodeAPI.raml
@@ -39,6 +39,10 @@ documentation:
 
       The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_proto' with a value of either 'http' or 'https' (lower-case) dependent on the protocol in use by the Node API web server.
 
+      **api\_ver**
+
+      The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_ver'. The value of this TXT record is a comma separated list of API versions supported by the server. For example: 'v1.0,v1.1,v2.0'. There should be no whitespace between commas, and versions should be listed in ascending order.
+
       **ver\_**
 
       When a Node is unable to locate or successfully register with a Registration API it MUST additionally advertise the following mDNS TXT records as part of its Node advertisement. If a Node is successfully registered with a Registration API it MUST withdraw advertisements of these TXT records. There is no requirement to register these TXT records with a unicast DNS service.

--- a/APIs/NodeAPI.raml
+++ b/APIs/NodeAPI.raml
@@ -25,13 +25,23 @@ documentation:
   - title: Overview
     content: |
       The Node API is exposed by each NMOS Node in a system, regardless of whether it is possible for that Node to provide NMOS resources such as Flows, Sources etc. Data exposed by the Node API is used to populate the (distributed) registry via the Registration API. In smaller deployments the Node API is fetched from directly as required by Nodes which implement the Peer to Peer specification.
-  - title: mDNS Advertisement
+  - title: DNS-SD Advertisement
     content: |
-      Node APIs MUST produce an mDNS advertisement of the type \_nmos-node.\_tcp
+      Node APIs MUST produce an mDNS advertisement of the type \_nmos-node.\_tcp. This MAY be accompanied by a unicast DNS announcement of the same type.
 
-      The IP address and port of the Node API MUST be identified via the mDNS advertisement, with the HTTP path then being resolved via the standard NMOS API path documentation.
+      The IP address and port of the Node API MUST be identified via the DNS-SD advertisement, with the full HTTP path then being resolved via the standard NMOS API path documentation.
 
-      When a Node is unable to locate or successfully register with a Registration API it MUST additionally advertise the following mDNS TXT records as part of its Node advertisement. If a Node is successfully registered with a Registration API it MUST withdraw advertisements of these TXT records.
+      Multiple DNS-SD advertisements for the same API are permitted where the API is exposed via multiple ports and/or protocols.
+
+  - title: DNS-SD TXT Records
+    content: |
+      **api\_proto**
+
+      The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_proto' with a value of either 'http' or 'https' (lower-case) dependent on the protocol in use by the Node API web server.
+
+      **ver\_**
+
+      When a Node is unable to locate or successfully register with a Registration API it MUST additionally advertise the following mDNS TXT records as part of its Node advertisement. If a Node is successfully registered with a Registration API it MUST withdraw advertisements of these TXT records. There is no requirement to register these TXT records with a unicast DNS service.
 
       | **TXT Record Name** | **Corresponding Node API Resource** |
       |---------------------|-------------------------------------|
@@ -45,6 +55,7 @@ documentation:
       The value of each of the above should be an unsigned 8-bit integer initialised to '0'. This integer MUST be incremented and mDNS TXT record updated whenever a change is made to the corresponding HTTP API resource on the Node. The integer must wrap back to a value of '0' after reaching a maximum value of '255' (MAX_UINT8_T).
 
       For example, the 'ver_src' TXT record must be created when the Node first advertises itself via mDNS. If the data held within the HTTP resource for /sources is added to, removed from or edited, then the 'ver_src' text record must be modified (value incremented).
+
   - title: Receiver Subscriptions
     content: |
       A PUT request to /receivers/{receiverId}/target will modify which Sender a Receiver is subscribed to.

--- a/APIs/QueryAPI.raml
+++ b/APIs/QueryAPI.raml
@@ -53,6 +53,9 @@ documentation:
     content: |
       The Query API MUST announce its 'priority' and 'weight' via its mDNS or unicast DNS SRV record as defined by RFC 2782.
 
+  - title: Websockets
+    content: |
+      Persistent connections to the Query API are supported via Websockets which can be set up via the /subscriptions resource. Query APIs may additionally support the HTTP 'Upgrade' header sent by clients to upgrade an HTTP GET request to a Websocket. In cases where this is performed, a corresponding entry in /subscriptions must also be created with matching query parameters.
 /:
   displayName: Base
   get:

--- a/APIs/QueryAPI.raml
+++ b/APIs/QueryAPI.raml
@@ -44,9 +44,14 @@ documentation:
 
       The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_ver'. The value of this TXT record is a comma separated list of API versions supported by the server. For example: 'v1.0,v1.1,v2.0'. There should be no whitespace between commas, and versions should be listed in ascending order.
 
-      **pri**
+      **pri (Deprecated)**
 
-      The DNS-SD advertisement MUST include a TXT record with key 'pri' and an integer value. Values 0 to 99 correspond to an active NMOS Query API (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system. NB: In future versions of the specification it is likely that the 'priority' and 'weight' as specified by RFC 2782 will be used.
+      The DNS-SD advertisement MUST include a TXT record with key 'pri' and an integer value. This is required to support v1.0 clients, and is scheduled for removal in v2.0. In version v1.1 and upwards, servers MUST additionally represent a matching priority via the DNS-SD SRV record 'priority' and 'weight' as defined in RFC 2782.
+      Before version 2.0 only: Values 0 to 99 correspond to an active NMOS Query API (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system.
+
+  - title: DNS-SD SRV Records
+    content: |
+      The Query API MUST announce its 'priority' and 'weight' via its mDNS or unicast DNS SRV record as defined by RFC 2782.
 
 /:
   displayName: Base

--- a/APIs/QueryAPI.raml
+++ b/APIs/QueryAPI.raml
@@ -40,6 +40,10 @@ documentation:
 
       The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_proto' with a value of either 'http' or 'https' dependent on the protocol in use by the Query API web server.
 
+      **api\_ver**
+
+      The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_ver'. The value of this TXT record is a comma separated list of API versions supported by the server. For example: 'v1.0,v1.1,v2.0'. There should be no whitespace between commas, and versions should be listed in ascending order.
+
       **pri**
 
       The DNS-SD advertisement MUST include a TXT record with key 'pri' and an integer value. Values 0 to 99 correspond to an active NMOS Query API (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system. NB: In future versions of the specification it is likely that the 'priority' and 'weight' as specified by RFC 2782 will be used.

--- a/APIs/QueryAPI.raml
+++ b/APIs/QueryAPI.raml
@@ -26,13 +26,24 @@ documentation:
       The Query API is exposed by NMOS discovery Nodes. It is used to expose the contents of the (distributed) registry to all Nodes on the network. In smaller deployments where no such registry is available, Nodes with their own control capabilities fall back to interrogating Nodes directly using the Peer to Peer specification. This is a Read Only API.
 
       Attributes defined as 'Optional' MUST be returned by the Query API if they exist within the registry. The presence declaration relates more to whether it is required for them to be registered at the Registration API side, or presented via the Node API.
-  - title: mDNS Advertisement
+  - title: DNS-SD Advertisement
     content: |
-      Query APIs MUST produce an mDNS advertisement of the type \_nmos-query.\_tcp
+      Query APIs MUST produce an mDNS advertisement of the type \_nmos-query.\_tcp. This MAY be accompanied by a unicast DNS announcement of the same type.
 
-      The mDNS advertisement MUST include a TXT record with key 'pri' and an integer value. Values 0 to 99 correspond to an active NMOS Query API (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system. NB: In future versions of the specification it is likely that the 'priority' and 'weight' as specified by RFC 2782 will be used.
+      The IP address and port of the Query API MUST be identified via the DNS-SD advertisement, with the full HTTP path then being resolved via the standard NMOS API path documentation.
 
-      The IP address and port of the query API MUST be identified via the mDNS advertisement, with the HTTP path then being resolved via the standard NMOS API path documentation.
+      Multiple DNS-SD advertisements for the same API are permitted where the API is exposed via multiple ports and/or protocols.
+
+  - title: DNS-SD TXT Records
+    content: |
+      **api\_proto**
+
+      The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_proto' with a value of either 'http' or 'https' dependent on the protocol in use by the Query API web server.
+
+      **pri**
+
+      The DNS-SD advertisement MUST include a TXT record with key 'pri' and an integer value. Values 0 to 99 correspond to an active NMOS Query API (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system. NB: In future versions of the specification it is likely that the 'priority' and 'weight' as specified by RFC 2782 will be used.
+
 /:
   displayName: Base
   get:

--- a/APIs/RegistrationAPI.raml
+++ b/APIs/RegistrationAPI.raml
@@ -25,6 +25,10 @@ documentation:
 
       The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_proto' with a value of either 'http' or 'https' dependent on the protocol in use by the Registration API web server.
 
+      **api\_ver**
+
+      The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_ver'. The value of this TXT record is a comma separated list of API versions supported by the server. For example: 'v1.0,v1.1,v2.0'. There should be no whitespace between commas, and versions should be listed in ascending order.
+
       **pri**
 
       The DNS-SD advertisement MUST include a TXT record with key 'pri' and an integer value. Values 0 to 99 correspond to an active NMOS Registration API (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system. NB: In future versions of the specification it is likely that the 'priority' and 'weight' as specified by RFC 2782 will be used.

--- a/APIs/RegistrationAPI.raml
+++ b/APIs/RegistrationAPI.raml
@@ -11,13 +11,23 @@ documentation:
   - title: Overview
     content: |
       The Registration API is exposed by NMOS discovery Nodes. It is used to publish data to the distributed registry, which can then be queried via the Query API. In smaller deployments where no distributed registry is available, the Registration API is not used and discovery responsibilities fall to individual Nodes which choose to implement Peer to Peer specification. The Registration API is a Write Only API.
-  - title: mDNS Advertisement
+  - title: DNS-SD Advertisement
     content: |
-      Registration APIs MUST produce an mDNS advertisement of the type \_nmos-registration.\_tcp
+      Registration APIs MUST produce an mDNS advertisement of the type \_nmos-registration.\_tcp. This MAY be accompanied by a unicast DNS announcement of the same type.
 
-      The mDNS advertisement MUST include a TXT record with key 'pri' and an integer value. Values 0 to 99 correspond to an active NMOS Registration API (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system. NB: In future versions of the specification it is likely that the 'priority' and 'weight' as specified by RFC 2782 will be used.
+      The IP address and port of the Registration API MUST be identified via the DNS-SD advertisement, with the full HTTP path then being resolved via the standard NMOS API path documentation.
 
-      The IP address and port of the registration API MUST be identified via the mDNS advertisement, with the HTTP path then being resolved via the standard NMOS API path documentation.
+      Multiple DNS-SD advertisements for the same API are permitted where the API is exposed via multiple ports and/or protocols.
+
+  - title: DNS-SD TXT Records
+    content: |
+      **api\_proto**
+
+      The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_proto' with a value of either 'http' or 'https' dependent on the protocol in use by the Registration API web server.
+
+      **pri**
+
+      The DNS-SD advertisement MUST include a TXT record with key 'pri' and an integer value. Values 0 to 99 correspond to an active NMOS Registration API (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system. NB: In future versions of the specification it is likely that the 'priority' and 'weight' as specified by RFC 2782 will be used.
 
 /:
   displayName: Base

--- a/APIs/RegistrationAPI.raml
+++ b/APIs/RegistrationAPI.raml
@@ -29,9 +29,14 @@ documentation:
 
       The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_ver'. The value of this TXT record is a comma separated list of API versions supported by the server. For example: 'v1.0,v1.1,v2.0'. There should be no whitespace between commas, and versions should be listed in ascending order.
 
-      **pri**
+      **pri (Deprecated)**
 
-      The DNS-SD advertisement MUST include a TXT record with key 'pri' and an integer value. Values 0 to 99 correspond to an active NMOS Registration API (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system. NB: In future versions of the specification it is likely that the 'priority' and 'weight' as specified by RFC 2782 will be used.
+      The DNS-SD advertisement MUST include a TXT record with key 'pri' and an integer value. This is required to support v1.0 clients, and is scheduled for removal in v2.0. In version v1.1 and upwards, servers MUST additionally represent a matching priority via the DNS-SD SRV record 'priority' and 'weight' as defined in RFC 2782.
+      Before version 2.0 only: Values 0 to 99 correspond to an active NMOS Registration API (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system.
+
+  - title: DNS-SD SRV Records
+    content: |
+      The Registration API MUST announce its 'priority' and 'weight' via its mDNS or unicast DNS SRV record as defined by RFC 2782.
 
 /:
   displayName: Base

--- a/APIs/schemas/node.json
+++ b/APIs/schemas/node.json
@@ -9,6 +9,7 @@
     "label",
     "href",
     "caps",
+    "api",
     "services"
   ],
   "properties": {
@@ -27,14 +28,55 @@
       "type": "string"
     },
     "href": {
-      "description": "HTTP access href for the Node's API",
+      "description": "HTTP access href for the Node's API (deprecated)",
       "type": "string",
       "format": "uri"
     },
     "hostname": {
-      "description": "Node hostname (optional)",
+      "description": "Node hostname (optional, deprecated)",
       "type": "string",
       "format": "hostname"
+    },
+    "api": {
+      "description": "URL fragments required to connect to the Node API",
+      "type": "object",
+      "required": ["versions", "endpoints"],
+      "properties": {
+        "versions": {
+          "description": "Supported API versions running on this Node",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "v[0-9]+.[0-9]+"
+          }
+        },
+        "endpoints": {
+          "description": "Host, port and protocol details required to connect to the API",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["host", "port", "protocol"],
+            "properties": {
+              "host": {
+                "type": "string",
+                "description": "IP address or hostname which the Node API is running on",
+                "format": ["hostname", "ipv4", "ipv6"]
+              },
+              "port": {
+                "type": "integer",
+                "description": "Port number which the Node API is running on",
+                "minimum": 1,
+                "maximum": 65535
+              },
+              "protocol": {
+                "type": "string",
+                "description": "Protocol supported by this instance of the Node API",
+                "enum": ["http", "https"]
+              }
+            }
+          }
+        }
+      }
     },
     "caps": {
       "description": "Capabilities (not yet defined)",

--- a/APIs/schemas/queryapi-v1.1-subscriptions-post-request.json
+++ b/APIs/schemas/queryapi-v1.1-subscriptions-post-request.json
@@ -20,6 +20,10 @@
       "type": "boolean",
       "default": false
     },
+    "secure": {
+      "description": "Whether to produce a secure websocket connection (wss://). NB: Default should be 'false' if the API is being presented via HTTP, and 'true' for HTTPS",
+      "type": "boolean"
+    },
     "resource_path": {
       "description": "HTTP resource path in the query API which this subscription relates to",
       "type": "string",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This document provides an overview of changes between released versions of this 
 ## Release (unreleased)
 * Under active development
 
+* Add multi-protocol support and version identification to Node API /self and hence Query API /nodes
 * Add 'api\_proto' TXT records to DNS-SD advertisements
 * Add 'api\_ver' TXT records to DNS-SD advertisements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This document provides an overview of changes between released versions of this 
 * Under active development
 
 * Add 'api\_proto' TXT records to DNS-SD advertisements
+* Add 'api\_ver' TXT records to DNS-SD advertisements
 
 ## Release v1.0
 * Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This document provides an overview of changes between released versions of this 
 * Add multi-protocol support and version identification to Node API /self and hence Query API /nodes
 * Add 'api\_proto' TXT records to DNS-SD advertisements
 * Add 'api\_ver' TXT records to DNS-SD advertisements
+* Add guidance on use of DNS SRV record priority and weight
 
 ## Release v1.0
 * Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,7 @@ This document provides an overview of changes between released versions of this 
 ## Release (unreleased)
 * Under active development
 
+* Add 'api\_proto' TXT records to DNS-SD advertisements
+
 ## Release v1.0
 * Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This document provides an overview of changes between released versions of this 
 * Add 'api\_proto' TXT records to DNS-SD advertisements
 * Add 'api\_ver' TXT records to DNS-SD advertisements
 * Add guidance on use of DNS SRV record priority and weight
+* Add support for secure websockets to the Query API
 
 ## Release v1.0
 * Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This document provides an overview of changes between released versions of this 
 * Add 'api\_ver' TXT records to DNS-SD advertisements
 * Add guidance on use of DNS SRV record priority and weight
 * Add support for secure websockets to the Query API
+* Add support for Upgrade headers when using websockets
 
 ## Release v1.0
 * Initial release

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -33,6 +33,10 @@ http(s)://<ip address or hostname>:<port>/x-nmos/<api type>/<api version>/
 
 At each level of the API from the base resource upwards, the response SHOULD include a JSON format array of the child resources available from that point.
 
+API clients using DNS-SD for API discovery SHOULD construct these paths by making use of the TXT records 'api\_proto' and 'api\_ver', along with addresses and ports resolved via DNS-SD. API clients which are discovering Node APIs via a Query API SHOULD construct Node API paths using the corresponding data available within the \'api\' attributes within the Query API /nodes/ path.
+
+Where protocol and versioning data is not available, clients MAY assume a v1.0 API, which operates via the 'http' protocol only.
+
 ### Versioning
 
 All public APIs are versioned as follows:

--- a/docs/3.0. Discovery.md
+++ b/docs/3.0. Discovery.md
@@ -21,7 +21,7 @@ When performing a DNS-SD browse, clients should proceed as follows:
 1. Identify whether the client has been configured with DNS server addresses and a default search domain either manually or automatically via DHCP.
 2. If such configuration exists, perform a unicast DNS browse for services of type '\_nmos-registration.\_tcp' via the search domain.
 3. Perform a multicast DNS browse for services of type '\_nmos-registration.\_tcp' in the '.local' domain.
-4. Merge the results of the two operations into a list, sorted using the priority values associated with each record.
+4. Merge the results of the two operations into a list, sorted using the 'priority' and 'weight' values associated with each DNS SRV record.
 5. The above list should be maintained via the methods defined by the DNS-SD specification.
 
 ## Implementation Notes

--- a/docs/4.1. Behaviour - Registration.md
+++ b/docs/4.1. Behaviour - Registration.md
@@ -28,7 +28,7 @@ The data model employed by NMOS allows for this situation by modelling a single 
 
 This mode of operation is applicable to both the 'Peer to Peer' and 'Registered' discovery case. It is also envisaged in the Registered case that operation may be desirable with a single registry, or with two which operate totally independently on the two different networks.
 
-In order to support this mode and ensure persistence in the registry upon link failure, a Node operating in this mode may register with Registration APIs (and host its Node API) via multiple independent network interfaces. In the case where separate registries are deployed for the multiple network links the Node must ensure it registers the correct 'href' with each registry (see [Node API](../APIs/NodeAPI.raml) /self resource).
+In order to support this mode and ensure persistence in the registry upon link failure, a Node operating in this mode may register with Registration APIs (and host its Node API) via multiple independent network interfaces. In the case where separate registries are deployed for the multiple network links the Node must ensure it registers the correct 'href' with each registry (see [Node API](../APIs/NodeAPI.raml) /self resource). From v1.1, the 'api' attribute of the Node /self resource adds the capability to list multiple endpoints for the same Node API, removing the requirement for this 'href' specialisation.
 
 ![Registration example with two independent networks and registries](images/redundant-reg.png)
 

--- a/docs/6.0. Upgrade Path.md
+++ b/docs/6.0. Upgrade Path.md
@@ -15,3 +15,7 @@ Registrations with a Registration API must only proceed if the Node API version 
 ## Requirements for Registries (Registration and Query APIs)
 
 Implementers of the Registration and Query API must support at least one API version. It is however strongly recommended that Registration and Query APIs fully support at least two and preferably more consecutive API versions (if released). In doing so, facilities which include a large number of Nodes may stagger their equipment upgrades whilst maintaining compatibility with a single registry.
+
+When supporting multiple API versions, Registration and Query APIs must provide translations between resource representations which are registered against different versions of the API. For example, if a v1.0 resource registration is made and returned via a v1.1 Query API, the API must add any missing keys and values to that response to make it v1.1 compliant. Conversely if a v1.1 registration is made and returned via a v1.0 Query API, keys which would not have been valid at v1.0 must be removed from the response.
+
+In cases where missing data between API versions cannot be inferred, the values may be returned as 'null', or an empty array dependent on the data type. Note that for critical keys this may not be sufficient to ensure a functional system. As a result it is not advised to support large jumps between supported API versions. Upgrades to these specifications will ensure a guaranteed upgrade path between at least adjacent API versions.

--- a/docs/6.0. Upgrade Path.md
+++ b/docs/6.0. Upgrade Path.md
@@ -8,7 +8,7 @@ API versioning is specified in the [APIs](2.0. APIs.md) documentation, with proc
 
 ## Requirements for Nodes (Node APIs)
 
-Implementers of the Node API must support at least one API version, and may support more than one at a time. Note however that a Node must only perform interactions with a Registration API at a single version. Nodes implementing multiple API versions may provide a user-configurable choice for which API version to register using.
+Implementers of the Node API must support at least one API version, and may support more than one at a time. Note however that a Node must only perform interactions with a Registration API at a single version. Nodes implementing multiple API versions may provide a user-configurable choice for which API version to register and/or query using.
 
 Registrations with a Registration API must only proceed if the Node API version implemented exactly matches the API version used by the Registration API.
 
@@ -16,6 +16,15 @@ Registrations with a Registration API must only proceed if the Node API version 
 
 Implementers of the Registration and Query API must support at least one API version. It is however strongly recommended that Registration and Query APIs fully support at least two and preferably more consecutive API versions (if released). In doing so, facilities which include a large number of Nodes may stagger their equipment upgrades whilst maintaining compatibility with a single registry.
 
-When supporting multiple API versions, Registration and Query APIs must provide translations between resource representations which are registered against different versions of the API. For example, if a v1.0 resource registration is made and returned via a v1.1 Query API, the API must add any missing keys and values to that response to make it v1.1 compliant. Conversely if a v1.1 registration is made and returned via a v1.0 Query API, keys which would not have been valid at v1.0 must be removed from the response.
+When supporting multiple API versions, Query APIs must provide translations of resources for backwards compatibility. For example, if the registry contains a mixture of v1.0 and v1.1 resources, a v1.0 Query API must provide a response containing all of these resources by removing keys from v1.1 resources which are not present in v1.0.
 
-In cases where missing data between API versions cannot be inferred, the values may be returned as 'null', or an empty array dependent on the data type. Note that for critical keys this may not be sufficient to ensure a functional system. As a result it is not advised to support large jumps between supported API versions. Upgrades to these specifications will ensure a guaranteed upgrade path between at least adjacent API versions.
+Query APIs are not required to provide for forwards compatibility as it may be impossible to generate data for new attributes in schemas. As such, a v1.1 Query API response from a registry containing v1.0 and v1.1 data is only required to provide the v1.1 data in a response.
+
+## Performing Upgrades
+
+The following procedure is suggested for a live system which needs to migrate between API versions:
+
+* Upgrade the Query API(s) to support serving the new version of responses, whilst providing backwards compatibility to old versions active in the running system.
+* Upgrade the registry and Registration API(s) to support registrations using the new version, whilst continuing to support registrations at the old version.
+* Upgrade Nodes in the system to register against the new API version. Any Nodes which also perform querying should continue to query using the old version initially.
+* Once all relevant Nodes have been upgraded, Query API clients may be upgraded or instructed to perform queries against the new version.

--- a/examples/nodeapi-v1.1-self-get-200.json
+++ b/examples/nodeapi-v1.1-self-get-200.json
@@ -3,6 +3,21 @@
     "hostname": "host1", 
     "caps": {}, 
     "href": "http://172.29.80.65:12345/", 
+    "api": {
+        "versions": ["v1.0", "v1.1"],
+        "endpoints": [
+            {
+                "host": "172.29.80.65",
+                "port": 12345,
+                "protocol": "http"
+            },
+            {
+                "host": "172.29.80.65",
+                "port": 443,
+                "protocol": "https"
+            }
+        ]
+    },
     "services": [
         {
             "href": "http://172.29.80.65:12345/x-manufacturer/pipelinemanager/", 

--- a/examples/queryapi-v1.1-nodeid-get-200.json
+++ b/examples/queryapi-v1.1-nodeid-get-200.json
@@ -3,6 +3,16 @@
     "hostname": "host1", 
     "label": "host1", 
     "href": "http://172.29.176.102:12345/", 
+    "api": {
+        "versions": ["v1.1"],
+        "endpoints": [
+            {
+                "host": "172.29.176.102",
+                "port": 12345,
+                "protocol": "http"
+            }
+        ]
+    },
     "services": [
         {
             "href": "http://172.29.176.102:12345/x-manufacturer/status/", 

--- a/examples/queryapi-v1.1-nodes-get-200.json
+++ b/examples/queryapi-v1.1-nodes-get-200.json
@@ -4,6 +4,16 @@
         "hostname": "host1", 
         "label": "host1", 
         "href": "http://172.29.176.102:12345/", 
+        "api": {
+            "versions": ["v1.1"],
+            "endpoints": [
+                {
+                    "host": "172.29.176.102",
+                    "port": 12345,
+                    "protocol": "http"
+                }
+            ]
+        },
         "services": [
             {
                 "href": "http://172.29.176.102:12345/x-manufacturer/status/", 
@@ -26,6 +36,16 @@
         "hostname": "host2", 
         "label": "host2", 
         "href": "http://172.29.176.19:12345/", 
+        "api": {
+            "versions": ["v1.1"],
+            "endpoints": [
+                {
+                    "host": "172.29.176.19",
+                    "port": 12345,
+                    "protocol": "http"
+                }
+            ]
+        },
         "services": [
             {
                 "href": "http://172.29.176.19:12345/x-manufacturer/pipelinemanager/", 

--- a/examples/queryapi-v1.1-subscriptionid-get-200.json
+++ b/examples/queryapi-v1.1-subscriptionid-get-200.json
@@ -1,8 +1,9 @@
 {
-    "max_update_rate_ms": 100, 
-    "resource_path": "/nodes", 
-    "params": {}, 
-    "persist": false, 
-    "ws_href": "ws://172.29.80.52:8870/ws/?uid=7c903667-7113-4a8f-8865-1c63f9070a9e", 
+    "max_update_rate_ms": 100,
+    "resource_path": "/nodes",
+    "params": {},
+    "persist": false,
+    "secure": false,
+    "ws_href": "ws://172.29.80.52:8870/ws/?uid=7c903667-7113-4a8f-8865-1c63f9070a9e",
     "id": "7c903667-7113-4a8f-8865-1c63f9070a9e"
 }

--- a/examples/queryapi-v1.1-subscriptions-get-200.json
+++ b/examples/queryapi-v1.1-subscriptions-get-200.json
@@ -1,34 +1,38 @@
 [
     {
-        "max_update_rate_ms": 100, 
-        "resource_path": "/receivers", 
-        "params": {}, 
-        "persist": false, 
-        "ws_href": "ws://172.29.80.52:8870/ws/?uid=6a52dbd5-a737-4c4e-823f-909ade8f8bf4", 
+        "max_update_rate_ms": 100,
+        "resource_path": "/receivers",
+        "params": {},
+        "persist": false,
+        "secure": false,
+        "ws_href": "ws://172.29.80.52:8870/ws/?uid=6a52dbd5-a737-4c4e-823f-909ade8f8bf4",
         "id": "6a52dbd5-a737-4c4e-823f-909ade8f8bf4"
-    }, 
+    },
     {
-        "max_update_rate_ms": 100, 
-        "resource_path": "/nodes", 
-        "params": {}, 
-        "persist": false, 
-        "ws_href": "ws://172.29.80.52:8870/ws/?uid=7c903667-7113-4a8f-8865-1c63f9070a9e", 
+        "max_update_rate_ms": 100,
+        "resource_path": "/nodes",
+        "params": {},
+        "persist": false,
+        "secure": false,
+        "ws_href": "ws://172.29.80.52:8870/ws/?uid=7c903667-7113-4a8f-8865-1c63f9070a9e",
         "id": "7c903667-7113-4a8f-8865-1c63f9070a9e"
-    }, 
+    },
     {
-        "max_update_rate_ms": 100, 
-        "resource_path": "/senders", 
-        "params": {}, 
-        "persist": false, 
-        "ws_href": "ws://172.29.80.52:8870/ws/?uid=c5f5c1ad-f9e6-44c0-828f-da3f7cdef286", 
+        "max_update_rate_ms": 100,
+        "resource_path": "/senders",
+        "params": {},
+        "persist": false,
+        "secure": true,
+        "ws_href": "wss://172.29.80.52:8870/ws/?uid=c5f5c1ad-f9e6-44c0-828f-da3f7cdef286",
         "id": "c5f5c1ad-f9e6-44c0-828f-da3f7cdef286"
-    }, 
+    },
     {
-        "max_update_rate_ms": 100, 
-        "resource_path": "/flows", 
-        "params": {}, 
-        "persist": false, 
-        "ws_href": "ws://172.29.80.52:8870/ws/?uid=b0416004-f825-4623-bf90-575b5dd32f93", 
+        "max_update_rate_ms": 100,
+        "resource_path": "/flows",
+        "params": {},
+        "persist": false,
+        "secure": false,
+        "ws_href": "ws://172.29.80.52:8870/ws/?uid=b0416004-f825-4623-bf90-575b5dd32f93",
         "id": "b0416004-f825-4623-bf90-575b5dd32f93"
     }
 ]

--- a/examples/queryapi-v1.1-subscriptions-post-200.json
+++ b/examples/queryapi-v1.1-subscriptions-post-200.json
@@ -1,10 +1,11 @@
 {
-    "max_update_rate_ms": 100, 
-    "resource_path": "/nodes", 
+    "max_update_rate_ms": 100,
+    "resource_path": "/nodes",
     "params": {
         "label": "host1"
-    }, 
-    "persist": false, 
-    "ws_href": "ws://172.29.80.52:8870/ws/?uid=7c903667-7113-4a8f-8865-1c63f9070a9e", 
+    },
+    "persist": false,
+    "secure": false,
+    "ws_href": "ws://172.29.80.52:8870/ws/?uid=7c903667-7113-4a8f-8865-1c63f9070a9e",
     "id": "7c903667-7113-4a8f-8865-1c63f9070a9e"
 }

--- a/examples/queryapi-v1.1-subscriptions-post-request.json
+++ b/examples/queryapi-v1.1-subscriptions-post-request.json
@@ -1,8 +1,9 @@
 {
-    "max_update_rate_ms": 100, 
-    "resource_path": "/nodes", 
+    "max_update_rate_ms": 100,
+    "resource_path": "/nodes",
     "params": {
         "label": "host1"
-    }, 
-    "persist": false
-} 
+    },
+    "persist": false,
+    "secure": false
+}

--- a/examples/registrationapi-v1.1-resource-get-200.json
+++ b/examples/registrationapi-v1.1-resource-get-200.json
@@ -3,6 +3,21 @@
     "hostname": "host1",
     "label": "host1",
     "href": "http://172.29.80.65:12345/",
+    "api": {
+        "versions": ["v1.0", "v1.1"],
+        "endpoints": [
+            {
+                "host": "172.29.80.65",
+                "port": 12345,
+                "protocol": "http"
+            },
+            {
+                "host": "172.29.80.65",
+                "port": 443,
+                "protocol": "https"
+            }
+        ]
+    },
     "services": [
         {
             "href": "http://172.29.80.65:12345/x-manufacturer/pipelinemanager/",

--- a/examples/registrationapi-v1.1-resource-post-200.json
+++ b/examples/registrationapi-v1.1-resource-post-200.json
@@ -3,6 +3,21 @@
     "hostname": "host1",
     "label": "host1",
     "href": "http://172.29.80.65:12345/",
+    "api": {
+        "versions": ["v1.0", "v1.1"],
+        "endpoints": [
+            {
+                "host": "172.29.80.65",
+                "port": 12345,
+                "protocol": "http"
+            },
+            {
+                "host": "172.29.80.65",
+                "port": 443,
+                "protocol": "https"
+            }
+        ]
+    },
     "services": [
         {
             "href": "http://172.29.80.65:12345/x-manufacturer/pipelinemanager/",

--- a/examples/registrationapi-v1.1-resource-post-request.json
+++ b/examples/registrationapi-v1.1-resource-post-request.json
@@ -5,6 +5,21 @@
         "hostname": "host1",
         "label": "host1",
         "href": "http://172.29.80.65:12345/",
+        "api": {
+            "versions": ["v1.0", "v1.1"],
+            "endpoints": [
+                {
+                    "host": "172.29.80.65",
+                    "port": 12345,
+                    "protocol": "http"
+                },
+                {
+                    "host": "172.29.80.65",
+                    "port": 443,
+                    "protocol": "https"
+                }
+            ]
+        },
         "services": [
             {
                 "href": "http://172.29.80.65:12345/x-manufacturer/pipelinemanager/",


### PR DESCRIPTION
These changes cover:

- Clarifying the upgrade path and explicitly indicating when HTTPS is supported
  - Add DNS-SD TXT records for api_ver and api_proto
  - Add matching version and protocol data to the Node API /self resource
  - Add ‘secure’ boolean attribute to websocket subscriptions and optional support for Upgrade header to API endpoints
  - Prefer the DNS SRV record priority mechanism rather than TXT ‘pri’ record

A corresponding discussion is active as part of the AMWA Incubator Basecamp