### PR TITLE
API Updates for v1.1-dev (minor tweaks and additions, 3/3)

### DIFF
--- a/APIs/schemas/device.json
+++ b/APIs/schemas/device.json
@@ -10,7 +10,8 @@
     "type",
     "node_id",
     "senders",
-    "receivers"
+    "receivers",
+    "controls"
   ],
   "properties": {
     "id": {
@@ -51,6 +52,26 @@
       "items": {
         "type": "string",
         "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+      }
+    },
+    "controls": {
+      "description": "Control endpoints exposed for the Device",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["href", "type"],
+        "properties": {
+          "href": {
+            "type": "string",
+            "description": "URL to reach a control endpoint, whether http or otherwise",
+            "format": "uri"
+          },
+          "type": {
+            "type": "string",
+            "description": "URN identifying the control format",
+            "format": "uri"
+          }
+        }
       }
     }
   }

--- a/APIs/schemas/flow.json
+++ b/APIs/schemas/flow.json
@@ -11,6 +11,7 @@
     "format",
     "tags",
     "source_id",
+    "device_id",
     "parents"
   ],
   "properties": {
@@ -56,6 +57,11 @@
     },
     "source_id": {
       "description": "Globally unique identifier for the Source which initially created the Flow",
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+    "device_id": {
+      "description": "Globally unique identifier for the Device which initially created the Flow",
       "type": "string",
       "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
     },

--- a/APIs/schemas/sender.json
+++ b/APIs/schemas/sender.json
@@ -34,8 +34,9 @@
     },
     "flow_id": {
       "description": "ID of the Flow currently passing via this Sender",
-      "type": "string",
-      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+      "type": ["string", "null"],
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+      "default": null
     },
     "transport": {
       "description": "Transport type used by the Sender in URN format",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This document provides an overview of changes between released versions of this 
 * Add paging support to the Query API
 * Add paging support to the Node API
 * Add advanced query parameter support for the Query API
+* Add 'device\_id' to Flow attributes covering cases where a Device is a content transformer only
 
 ## Release v1.0
 * Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This document provides an overview of changes between released versions of this 
 * Add advanced query parameter support for the Query API
 * Add 'device\_id' to Flow attributes covering cases where a Device is a content transformer only
 * Permit Senders without attached Flows to model a Device before internal routing has been performed
+* Add support for exposing control endpoints from Devices
 
 ## Release v1.0
 * Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This document provides an overview of changes between released versions of this 
 * Add paging support to the Node API
 * Add advanced query parameter support for the Query API
 * Add 'device\_id' to Flow attributes covering cases where a Device is a content transformer only
+* Permit Senders without attached Flows to model a Device before internal routing has been performed
 
 ## Release v1.0
 * Initial release

--- a/examples/nodeapi-v1.1-deviceid-get-200.json
+++ b/examples/nodeapi-v1.1-deviceid-get-200.json
@@ -5,5 +5,19 @@
     "id": "67c25159-ce25-4000-a66c-f31fff890265",
     "type": "urn:x-nmos:device:pipeline",
     "senders": [],
-    "node_id": "3b8be755-08ff-452b-b217-c9151eb21193"
+    "node_id": "3b8be755-08ff-452b-b217-c9151eb21193",
+    "controls": [
+        {
+            "type": "urn:x-manufacturer:control:generic",
+            "href": "ws://182.54.54.75:223"
+        },
+        {
+            "type": "urn:x-manufacturer:control:generic",
+            "href": "http://134.24.64.22/x-manufacturer/control/"
+        },
+        {
+            "type": "urn:x-manufacturer:control:legacy",
+            "href": "telnet://120.43.64.3:8080"
+        }
+    ]
 }

--- a/examples/nodeapi-v1.1-devices-get-200.json
+++ b/examples/nodeapi-v1.1-devices-get-200.json
@@ -8,7 +8,13 @@
         "senders": [
             "d7aa5a30-681d-4e72-92fb-f0ba0f6f4c3e"
         ], 
-        "node_id": "3b8be755-08ff-452b-b217-c9151eb21193"
+        "node_id": "3b8be755-08ff-452b-b217-c9151eb21193",
+        "controls": [
+            {
+                "type": "urn:x-manufacturer:control:generic",
+                "href": "wss://154.67.63.2:4535"
+            }
+        ]
     }, 
     {
         "receivers": [], 
@@ -17,7 +23,21 @@
         "id": "67c25159-ce25-4000-a66c-f31fff890265", 
         "type": "urn:x-nmos:device:pipeline", 
         "senders": [], 
-        "node_id": "3b8be755-08ff-452b-b217-c9151eb21193"
+        "node_id": "3b8be755-08ff-452b-b217-c9151eb21193",
+        "controls": [
+            {
+                "type": "urn:x-manufacturer:control:generic",
+                "href": "ws://182.54.54.75:223"
+            },
+            {
+                "type": "urn:x-manufacturer:control:generic",
+                "href": "http://134.24.64.22/x-manufacturer/control/"
+            },
+            {
+                "type": "urn:x-manufacturer:control:legacy",
+                "href": "telnet://120.43.64.3:8080"
+            }
+        ]
     }, 
     {
         "receivers": [
@@ -28,6 +48,7 @@
         "id": "05017e08-b329-45f9-a566-a3f99cc11e4d", 
         "type": "urn:x-nmos:device:pipeline", 
         "senders": [], 
-        "node_id": "3b8be755-08ff-452b-b217-c9151eb21193"
+        "node_id": "3b8be755-08ff-452b-b217-c9151eb21193",
+        "controls": []
     }
 ]

--- a/examples/nodeapi-v1.1-flowid-get-200.json
+++ b/examples/nodeapi-v1.1-flowid-get-200.json
@@ -6,5 +6,6 @@
     "version": "1441704616:587121295",
     "parents": [],
     "source_id": "02c46999-d532-4c52-905f-2e368a2af6cb",
+    "device_id": "9126cc2f-4c26-4c9b-a6cd-93c4381c9be5",
     "id": "5fbec3b1-1b0f-417d-9059-8b94a47197ed"
 }

--- a/examples/nodeapi-v1.1-flows-get-200.json
+++ b/examples/nodeapi-v1.1-flows-get-200.json
@@ -7,6 +7,7 @@
         "version": "1441704616:587121295", 
         "parents": [],
         "source_id": "02c46999-d532-4c52-905f-2e368a2af6cb", 
+        "device_id": "9126cc2f-4c26-4c9b-a6cd-93c4381c9be5",
         "id": "5fbec3b1-1b0f-417d-9059-8b94a47197ed"
     },
     {
@@ -17,6 +18,7 @@
         "version": "1453880607:123995943", 
         "parents": [], 
         "source_id": "0e635152-e501-4d4e-bb87-9f3fe05eb79a", 
+        "device_id": "9126cc2f-4c26-4c9b-a6cd-93c4381c9be5",
         "id": "db3bd465-2772-484f-8fac-830b0471258b"
     }
 ]

--- a/examples/queryapi-v1.1-deviceid-get-200.json
+++ b/examples/queryapi-v1.1-deviceid-get-200.json
@@ -15,5 +15,11 @@
     "senders": [], 
     "id": "a370d258-69de-4422-860a-ee4cf32ee9f4", 
     "node_id": "3a25a674-e6eb-4987-84ad-ef479fe4d527",
-    "type": "urn:x-nmos:device:pipeline"
+    "type": "urn:x-nmos:device:pipeline",
+    "controls": [
+        {
+            "type": "urn:x-manufacturer:control:generic",
+            "href": "wss://154.67.62.2:4635"
+        }
+    ]
 }

--- a/examples/queryapi-v1.1-devices-get-200.json
+++ b/examples/queryapi-v1.1-devices-get-200.json
@@ -10,7 +10,13 @@
         ], 
         "id": "c501ae64-f525-48b7-9816-c5e8931bc017", 
         "node_id": "1d452562-e1d5-4e84-b057-5c24de5f6b48",
-        "type": "urn:x-nmos:device:pipeline"
+        "type": "urn:x-nmos:device:pipeline",
+        "controls": [
+            {
+                "type": "urn:x-manufacturer:control:generic",
+                "href": "http://124.54.36.2:465"
+            }
+        ]
     }, 
     {
         "receivers": [], 
@@ -19,7 +25,8 @@
         "senders": [], 
         "id": "a30e4fba-254a-4e97-8bf7-daec80b8e57f", 
         "node_id": "3b8be755-08ff-452b-b217-c9151eb21193",
-        "type": "urn:x-nmos:device:pipeline"
+        "type": "urn:x-nmos:device:pipeline",
+        "controls": []
     }, 
     {
         "receivers": [
@@ -32,7 +39,8 @@
         ], 
         "id": "e19ef82c-5f0a-48da-a86c-bb2377ab09a4", 
         "node_id": "4cf38bb4-d6c4-48d6-a086-6eac45d73ae5",
-        "type": "urn:x-nmos:device:pipeline"
+        "type": "urn:x-nmos:device:pipeline",
+        "controls": []
     }, 
     {
         "receivers": [
@@ -51,6 +59,12 @@
         "senders": [], 
         "id": "a370d258-69de-4422-860a-ee4cf32ee9f4", 
         "node_id": "3a25a674-e6eb-4987-84ad-ef479fe4d527",
-        "type": "urn:x-nmos:device:pipeline"
+        "type": "urn:x-nmos:device:pipeline",
+        "controls": [
+            {
+                "type": "urn:x-manufacturer:control:generic",
+                "href": "wss://154.67.62.2:4635"
+            }
+        ]
     }
 ]

--- a/examples/queryapi-v1.1-flowid-get-200.json
+++ b/examples/queryapi-v1.1-flowid-get-200.json
@@ -10,5 +10,6 @@
     "version": "1441812152:154331951", 
     "parents": [],
     "source_id": "2aa143ac-0ab7-4d75-bc32-5c00c13d186f", 
+    "device_id": "169feb2c-3fae-42a5-ae2e-f6f8cbce29cf",
     "id": "b3bb5be7-9fe9-4324-a5bb-4c70e1084449"
 }

--- a/examples/queryapi-v1.1-flows-get-200.json
+++ b/examples/queryapi-v1.1-flows-get-200.json
@@ -7,6 +7,7 @@
         "version": "1441724130:194944510", 
         "parents": [],
         "source_id": "c7b1c809-84d4-427d-b6bb-c8397c66ce2b", 
+        "device_id": "a711ddd3-376d-4d6d-934d-834e54e045b1",
         "id": "0c1f03d7-7e94-4b21-94d1-3ffbee8a0606"
     }, 
     {
@@ -17,6 +18,7 @@
         "version": "1441724130:186085940", 
         "parents": [],
         "source_id": "c7b1c809-84d4-427d-b6bb-c8397c66ce2b", 
+        "device_id": "a711ddd3-376d-4d6d-934d-834e54e045b1",
         "id": "0e85d87b-4b19-4452-aea3-984c9f94bbc9"
     }, 
     {
@@ -31,6 +33,7 @@
         "version": "1441812152:154331951", 
         "parents": [],
         "source_id": "2aa143ac-0ab7-4d75-bc32-5c00c13d186f", 
+        "device_id": "169feb2c-3fae-42a5-ae2e-f6f8cbce29cf",
         "id": "b3bb5be7-9fe9-4324-a5bb-4c70e1084449"
     }
 ]


### PR DESCRIPTION
These changes cover:

- Add a ‘controls’ attribute to Devices, permitting control endpoint exposure in the same style as Node ‘services’
- Add a device_id keys to Flow attributes, enabling Nodes which do not act as a Source (e.g. encoders, decoders, scalers)
- Permit ‘null’ flow_id against a Sender in order to allow advertisement before internal device routing has occurred

A corresponding discussion is active as part of the AMWA Incubator Basecamp