### PR TITLE
Signal unicast and non-NMOS connections between Senders and Receivers

### DIFF
--- a/APIs/NodeAPI.raml
+++ b/APIs/NodeAPI.raml
@@ -67,7 +67,7 @@ documentation:
 
   - title: Receiver Subscriptions
     content: |
-      This method is deprecated.  Please see NMOS Connection API specification for the current methods for creating connections between Senders and Receivers.  
+      This method is deprecated, but should be supported alongside any other connection mechanisms until it is removed in v2.0. Please see the NMOS Connection API specification for the current methods for creating connections between Senders and Receivers.
 
       A PUT request to /receivers/{receiverId}/target will modify which Sender a Receiver is subscribed to.
 

--- a/APIs/schemas/receiver_core.json
+++ b/APIs/schemas/receiver_core.json
@@ -47,15 +47,19 @@
           }
         },
         "subscription": {
-          "description": "Object containing the 'sender_id' currently subscribed to. Sender_id should be null on initialisation.",
+          "description": "Object containing the 'sender_id' currently subscribed to. Sender_id should be null on initialisation, or when connected to a non-NMOS Sender.",
           "type": "object",
-          "required": ["sender_id"],
+          "required": ["sender_id", "active"],
           "properties": {
             "sender_id": {
               "type": ["string", "null"],
               "description": "UUID of the Sender that this Receiver is currently subscribed to",
               "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
               "default": null
+            },
+            "active": {
+              "type": "boolean",
+              "description": "Receiver is enabled and configured with a Sender's connection parameters"
             }
           }
         }

--- a/APIs/schemas/receiver_core.json
+++ b/APIs/schemas/receiver_core.json
@@ -59,7 +59,8 @@
             },
             "active": {
               "type": "boolean",
-              "description": "Receiver is enabled and configured with a Sender's connection parameters"
+              "description": "Receiver is enabled and configured with a Sender's connection parameters",
+              "default": false
             }
           }
         }

--- a/APIs/schemas/sender.json
+++ b/APIs/schemas/sender.json
@@ -53,7 +53,7 @@
           "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "manifest_href": {
-          "description": "HTTP URL to a file describing how to connect to the Sender (SDP for RTP)",
+          "description": "HTTP URL to a file describing how to connect to the Sender (SDP for RTP). The Sender's 'version' attribute should be updated if the contents of this file are modified.",
           "type": "string",
           "format": "uri"
         },
@@ -62,6 +62,23 @@
           "type": "array",
           "items": {
             "type":"string"
+          }
+        },
+        "subscription": {
+          "description": "Object containing the 'receiver_id' currently subscribed to (unicast only). Receiver_id should be null on initialisation, or when connected to a non-NMOS unicast Receiver.",
+          "type": "object",
+          "required": ["receiver_id", "active"],
+          "properties": {
+            "receiver_id": {
+              "type": ["string", "null"],
+              "description": "UUID of the Receiver that this Sender is currently subscribed to",
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+              "default": null
+            },
+            "active": {
+              "type": "boolean",
+              "description": "Sender is enabled and configured to stream data to a single Receiver (unicast), or to the network via multicast or a pull-based mechanism"
+            }
           }
         }
       }

--- a/APIs/schemas/sender.json
+++ b/APIs/schemas/sender.json
@@ -12,7 +12,8 @@
         "transport",
         "device_id",
         "manifest_href",
-        "interface_bindings"
+        "interface_bindings",
+        "subscription"
       ],
       "properties": {
         "caps": {
@@ -77,7 +78,8 @@
             },
             "active": {
               "type": "boolean",
-              "description": "Sender is enabled and configured to stream data to a single Receiver (unicast), or to the network via multicast or a pull-based mechanism"
+              "description": "Sender is enabled and configured to stream data to a single Receiver (unicast), or to the network via multicast or a pull-based mechanism",
+              "default": false
             }
           }
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This document provides an overview of changes between released versions of this 
 * Add network interfaces and bindings to Nodes, Senders and Receivers
 * Deprecate native Node API connection management interface
 * Deprecate Sender and Receiver arrays within Devices
+* Add signalling for active connections to unicast Senders, or non-NMOS Devices
 
 ## Release v1.1
 * Add multi-protocol support and version identification to Node API /self and hence Query API /nodes

--- a/examples/nodeapi-v1.1-receiverid-get-200.json
+++ b/examples/nodeapi-v1.1-receiverid-get-200.json
@@ -8,7 +8,8 @@
         ]
     },
     "subscription": {
-        "sender_id": "2683ad14-642f-459d-a169-ef91c76cec6b"
+        "sender_id": "2683ad14-642f-459d-a169-ef91c76cec6b",
+        "active": true
     },
     "version": "1441704532:450093308",
     "label": "RTPRx",

--- a/examples/nodeapi-v1.1-receivers-get-200.json
+++ b/examples/nodeapi-v1.1-receivers-get-200.json
@@ -9,11 +9,12 @@
             ]
         },
         "subscription": {
-            "sender_id": "2683ad14-642f-459d-a169-ef91c76cec6b"
+            "sender_id": "2683ad14-642f-459d-a169-ef91c76cec6b",
+            "active": true
         },
         "version": "1441704532:450093308",
         "label": "RTPRx",
-        "id": "1eb53d65-ac83-441c-86f6-9b27df30ef0c", 
+        "id": "1eb53d65-ac83-441c-86f6-9b27df30ef0c",
         "transport": "urn:x-nmos:transport:rtp",
         "interface_bindings":[
           "eth0",

--- a/examples/nodeapi-v1.1-senderid-get-200.json
+++ b/examples/nodeapi-v1.1-senderid-get-200.json
@@ -12,5 +12,9 @@
       "eth1"
     ],
     "caps": {},
-    "tags": {}
+    "tags": {},
+    "subscription": {
+      "receiver_id": null,
+      "active": true
+    }
 }

--- a/examples/nodeapi-v1.1-senders-get-200.json
+++ b/examples/nodeapi-v1.1-senders-get-200.json
@@ -13,6 +13,10 @@
           "eth1"
         ],
         "caps": {},
-        "tags": {}
+        "tags": {},
+        "subscription": {
+            "receiver_id": null,
+            "active": true
+        }
     }
 ]

--- a/examples/queryapi-v1.1-receiverid-get-200.json
+++ b/examples/queryapi-v1.1-receiverid-get-200.json
@@ -20,6 +20,7 @@
       "eth1"
     ],
     "subscription": {
-        "sender_id": "55311762-8003-48fa-a645-0a0c7621ce45"
+        "sender_id": "55311762-8003-48fa-a645-0a0c7621ce45",
+        "active": true
     }
 }

--- a/examples/queryapi-v1.1-receivers-get-200.json
+++ b/examples/queryapi-v1.1-receivers-get-200.json
@@ -22,7 +22,8 @@
           "en1"
         ],
         "subscription": {
-            "sender_id": "55311762-8003-48fa-a645-0a0c7621ce45"
+            "sender_id": "55311762-8003-48fa-a645-0a0c7621ce45",
+            "active": true
         }
     },
     {
@@ -48,7 +49,8 @@
           "eth1"
         ],
         "subscription": {
-            "sender_id": "a325cfe1-47ee-4a23-9a5c-7b5fcb9c2bb2"
+            "sender_id": "a325cfe1-47ee-4a23-9a5c-7b5fcb9c2bb2",
+            "active": true
         }
     },
     {
@@ -70,7 +72,8 @@
           "eth0"
         ],
         "subscription": {
-            "sender_id": null
+            "sender_id": null,
+            "active": false
         }
     }
 ]

--- a/examples/queryapi-v1.1-senderid-get-200.json
+++ b/examples/queryapi-v1.1-senderid-get-200.json
@@ -12,5 +12,9 @@
     ],
     "device_id": "c501ae64-f525-48b7-9816-c5e8931bc017",
     "caps": {},
-    "tags": {}
+    "tags": {},
+    "subscription": {
+      "receiver_id": null,
+      "active": true
+    }
 }

--- a/examples/queryapi-v1.1-senders-get-200.json
+++ b/examples/queryapi-v1.1-senders-get-200.json
@@ -13,7 +13,11 @@
         ],
         "device_id": "3a98e804-9871-4699-ba31-d608309d8933",
         "caps": {},
-        "tags": {}
+        "tags": {},
+        "subscription": {
+            "receiver_id": null,
+            "active": true
+        }
     },
     {
         "description": "Camera 2",
@@ -28,7 +32,11 @@
         ],
         "device_id": "c501ae64-f525-48b7-9816-c5e8931bc017",
         "caps": {},
-        "tags": {}
+        "tags": {},
+        "subscription": {
+            "receiver_id": null,
+            "active": true
+        }
     },
     {
         "description": "Camera 2 Audio",
@@ -43,6 +51,10 @@
         ],
         "device_id": "5f88d383-596c-409c-887e-a90e42ef3684",
         "caps": {},
-        "tags": {}
+        "tags": {},
+        "subscription": {
+            "receiver_id": null,
+            "active": true
+        }
     }
 ]


### PR DESCRIPTION
This patch adds support for signalling a unicast connection between and NMOS Sender and Receiver. Additionally it indicates whether a Sender or Receiver is currently configured and enabled in order to indicate an active connection which may be between an NMOS and non-NMOS Sender and Receiver.