### PR TITLE
Documentation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-This document provides an overview of changes between released versions of this specification. It is particularly important to consider this when implementing Registration and Query APIs which may support multiple releases simultaneously to ease upgrades in large facilities (see [Upgrade Path](docs/6.0. Upgrade Path.md)).
+This document provides an overview of changes between released versions of this specification. It is particularly important to consider this when implementing Registration and Query APIs which may support multiple releases simultaneously to ease upgrades in large facilities (see [Upgrade Path](docs/6.0.%20Upgrade%20Path.md)).
 
 ## Release (unreleased)
 * Under active development

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains details of this AMWA Specification, including Node, Reg
 
 ## Getting started
 
-Readers are advised to be familiar with the JT-NM Reference Architecture (http://jt-nm.org/), before starting with the [Overview](docs/1.0. Overview.md) in this repository. The API specifications are written in RAML -- if a suitable tool is not available for reading this, then [this](APIs/generateHTML) will create HTML versions.
+Readers are advised to be familiar with the JT-NM Reference Architecture (http://jt-nm.org/), before starting with the [Overview](docs/1.0.%20Overview.md) in this repository. The API specifications are written in RAML -- if a suitable tool is not available for reading this, then [this](APIs/generateHTML) will create HTML versions.
 
 ## Releases
 
@@ -15,7 +15,7 @@ Each version of the specification is available under a v&lt;#MAJOR&gt;.&lt;#MINO
 ## Contents
 
 * README.md -- This file
-* [docs/1.0. Overview.md](docs/1.0. Overview.md) -- Documentation targeting those implementing APIs and clients. Further topics are covered within the [docs/](docs/) directory
+* [docs/1.0. Overview.md](docs/1.0.%20Overview.md) -- Documentation targeting those implementing APIs and clients. Further topics are covered within the [docs/](docs/) directory
 * [APIs/NodeAPI.raml](APIs/NodeAPI.raml) -- Normative specification of the NMOS Node API
 * [APIs/RegistrationAPI.raml](APIs/RegistrationAPI.raml) -- Normative specification of the NMOS Registration API
 * [APIs/QueryAPI.raml](APIs/QueryAPI.raml) -- Normative specification of the NMOS Query API

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -6,7 +6,7 @@ _(c) AMWA 2016, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
 
 The documents included in this directory provide additional details and recommendations for implementations of the defined APIs, or their consumers.
 
-Familiarity with the JT-NM reference architecture (http://jt-nm.org/) is assumed, but a summary of the resources referenced by this specification is available in the [Data Model](5.0. Data Model.md).
+Familiarity with the JT-NM reference architecture (http://jt-nm.org/) is assumed, but a summary of the resources referenced by this specification is available in the [Data Model](5.0.%20Data%20Model.md).
 
 ## Introduction
 
@@ -14,7 +14,7 @@ The purpose of this document is to explain how the individual entities in an NMO
 
 In NMOS, all Nodes (logical hosts) expose one or more APIs:
 
-* The [Node API](../APIs/NodeAPI.raml) is present on all Nodes to provide a means of finding the resources on each Node. The Node API also plays an important role in [Peer-to-peer discovery](3.2. Discovery - Peer to Peer Operation.md), and is expected to be used by future NMOS specifications, e.g. for connection management.
+* The [Node API](../APIs/NodeAPI.raml) is present on all Nodes to provide a means of finding the resources on each Node. The Node API also plays an important role in [Peer-to-peer discovery](3.2.%20Discovery%20-%20Peer%20to%20Peer%20Operation.md), and is expected to be used by future NMOS specifications, e.g. for connection management.
 * The [Registration](../APIs/RegistrationAPI.raml) and [Query](../APIs/QueryAPI.raml) APIs are present on Nodes that enable registry-based discovery.
 
 ## Requirements on Nodes
@@ -23,7 +23,7 @@ A Node MUST implement the [Node API](../APIs/NodeAPI.raml).
 
 A Node MUST attempt to interact with the [Registration API](../APIs/RegistrationAPI.raml).
 
-Clients requiring data about other Nodes in the system (such as connection managers) MUST obtain this via the [Query API](../APIs/QueryAPI.raml) if available, or by using the [Peer-to-peer specification](3.2. Discovery - Peer to Peer Operation.md) in smaller networks.
+Clients requiring data about other Nodes in the system (such as connection managers) MUST obtain this via the [Query API](../APIs/QueryAPI.raml) if available, or by using the [Peer-to-peer specification](3.2.%20Discovery%20-%20Peer%20to%20Peer%20Operation.md) in smaller networks.
 
 ### Node Structure
 

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -50,7 +50,7 @@ All public APIs are versioned as follows:
 A v1.1 API response may include:
 * v1.1 data without modification.
 * Data conforming to schemas less than v2.0 but greater than v1.1, with any non-v1.1 keys removed.
-* Query API only: Data confirming to schemas less than v1.1 but greater than or equal to v1.0 if a suitable downgrade parameter is specified (see [Query Parameters](2.5. APIs - Query Parameters.md)).
+* Query API only: Data confirming to schemas less than v1.1 but greater than or equal to v1.0 if a suitable downgrade parameter is specified (see [Query Parameters](2.5.%20APIs%20-%20Query%20Parameters.md)).
 
 ### Common API Base Resource
 
@@ -89,4 +89,4 @@ The NMOS APIs use HTTP status codes to indicate success, failure and other cases
 
 In the above example, the 'code' should always match the HTTP status code. 'error' must always be present and in string format. 'debug' may be null if no further debug information is available.
 
-Further details on when APIs will respond with particular codes is covered in the [Behaviour](4.0. Behaviour.md) section.
+Further details on when APIs will respond with particular codes is covered in the [Behaviour](4.0.%20Behaviour.md) section.

--- a/docs/2.2. APIs - Client Side Implementation Notes.md
+++ b/docs/2.2. APIs - Client Side Implementation Notes.md
@@ -8,4 +8,4 @@ For clients which need to discover the services of a Query API, but operate in s
 
 ## Failure Modes
 
-The NMOS Registration and Query APIs are designed to be highly available and support failover without any visible consequence for a user operating a system which depends upon them. Recommended handling of common error codes and scenarios is covered in [Behaviour](4.0. Behaviour.md).
+The NMOS Registration and Query APIs are designed to be highly available and support failover without any visible consequence for a user operating a system which depends upon them. Recommended handling of common error codes and scenarios is covered in [Behaviour](4.0.%20Behaviour.md).

--- a/docs/3.0. Discovery.md
+++ b/docs/3.0. Discovery.md
@@ -10,7 +10,7 @@ Three DNS-SD service types are defined by this specification:
 * **_nmos-registration._tcp** A logical host which advertises a Registration API.
 * **_nmos-query._tcp** A logical host which advertises a Query API.
 
-Advertisements of the above types may be accompanied by DNS TXT records as specified within the API RAML documentation.
+Advertisements of the above types are accompanied by DNS TXT records as specified within the API RAML documentation.
 
 ## Unicast vs. Multicast DNS-SD
 

--- a/docs/4.1. Behaviour - Registration.md
+++ b/docs/4.1. Behaviour - Registration.md
@@ -18,7 +18,7 @@ The following behaviour assumes a Node with a single network interface for all t
 4. The Node performs a DNS-SD browse for services of type '\_nmos-registration.\_tcp' as specified in [Discovery: Registered Operation](3.1. Discovery - Registered Operation.md).
 5. The Node registers itself with the Registration API by taking the object it holds under the Node API's /self resource and POSTing this to the Registration API.
 6. The Node persists itself in the registry by issuing heartbeats as below.
-7. The Node registers its other resources (from /devices, /sources etc) with the Registration API.
+7. The Node registers its other resources (from /devices, /sources etc) with the Registration API. Note that resources must be registered in the correct order, such that a Receiver which references a device_id is registered after that corresponding Device (for example).
 
 #### Resilient Node Behaviour
 

--- a/docs/4.1. Behaviour - Registration.md
+++ b/docs/4.1. Behaviour - Registration.md
@@ -15,7 +15,7 @@ The following behaviour assumes a Node with a single network interface for all t
 1. A Node is connected to the network
 2. The Node runs an HTTP accessible Node API.
 3. The Node produces an mDNS advertisement of type '\_nmos-node.\_tcp' in the '.local' domain as specified in [Node API](../APIs/NodeAPI.raml).
-4. The Node performs a DNS-SD browse for services of type '\_nmos-registration.\_tcp' as specified in [Discovery: Registered Operation](3.1. Discovery - Registered Operation.md).
+4. The Node performs a DNS-SD browse for services of type '\_nmos-registration.\_tcp' as specified in [Discovery: Registered Operation](3.1.%20Discovery%20-%20Registered%20Operation.md).
 5. The Node registers itself with the Registration API by taking the object it holds under the Node API's /self resource and POSTing this to the Registration API.
 6. The Node persists itself in the registry by issuing heartbeats as below.
 7. The Node registers its other resources (from /devices, /sources etc) with the Registration API. Note that resources must be registered in the correct order, such that a Receiver which references a device_id is registered after that corresponding Device (for example).
@@ -68,7 +68,7 @@ If a Node is restarted, its first action upon discovering a Registration API is 
 
 ### Node Encounters HTTP 400 (or other 4xx) On Registration
 
-A 400 error indicates a client error which is likely to be the result of a validation failure identified by the Registration API. The same request must not be re-attempted without corrective action being taken first. Error responses as detailed in the [APIs](../APIs/2.0. APIs.md) documentation may assist with debugging these issues.
+A 400 error indicates a client error which is likely to be the result of a validation failure identified by the Registration API. The same request must not be re-attempted without corrective action being taken first. Error responses as detailed in the [APIs](../APIs/2.0.%20APIs.md) documentation may assist with debugging these issues.
 
 ### Node Encounters HTTP 404 On Heartbeat
 

--- a/docs/6.0. Upgrade Path.md
+++ b/docs/6.0. Upgrade Path.md
@@ -4,7 +4,7 @@ _(c) AMWA 2016, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
 
 As is common with web APIs, over time changes will be made to support new use cases and deprecate old ways of working. The NMOS APIs are no different, and have been designed to permit in-service upgrades across a facility which may be running large amounts of equipment with support for different versions of these specifications.
 
-API versioning is specified in the [APIs](2.0. APIs.md) documentation, with procedures for handling upgrades described below.
+API versioning is specified in the [APIs](2.0.%20APIs.md) documentation, with procedures for handling upgrades described below.
 
 ## Requirements for Nodes (Node APIs)
 

--- a/examples/nodeapi-v1.1-senderid-get-200.json
+++ b/examples/nodeapi-v1.1-senderid-get-200.json
@@ -2,7 +2,7 @@
     "description": "Test Card",
     "label": "Test Card",
     "version": "1441704616:890020555",
-    "manifest_href": "http://172.29.80.65:12345/x-nmos/node/v1.1/self/pipelinemanager/run/pipeline/3/pipel/ipp_rtptxfefa/misc/sdp/stream.sdp",
+    "manifest_href": "http://172.29.80.65/x-manufacturer/senders/d7aa5a30-681d-4e72-92fb-f0ba0f6f4c3e/stream.sdp",
     "flow_id": "5fbec3b1-1b0f-417d-9059-8b94a47197ed",
     "id": "d7aa5a30-681d-4e72-92fb-f0ba0f6f4c3e",
     "transport": "urn:x-nmos:transport:rtp.mcast",

--- a/examples/nodeapi-v1.1-senders-get-200.json
+++ b/examples/nodeapi-v1.1-senders-get-200.json
@@ -3,7 +3,7 @@
         "description": "Test Card",
         "label": "Test Card",
         "version": "1441704616:890020555",
-        "manifest_href": "http://172.29.80.65:12345/x-nmos/node/v1.1/self/pipelinemanager/run/pipeline/3/pipel/ipp_rtptxfefa/misc/sdp/stream.sdp",
+        "manifest_href": "http://172.29.80.65/x-manufacturer/senders/d7aa5a30-681d-4e72-92fb-f0ba0f6f4c3e/stream.sdp",
         "flow_id": "5fbec3b1-1b0f-417d-9059-8b94a47197ed",
         "id": "d7aa5a30-681d-4e72-92fb-f0ba0f6f4c3e",
         "transport": "urn:x-nmos:transport:rtp.mcast",

--- a/examples/queryapi-v1.1-senderid-get-200.json
+++ b/examples/queryapi-v1.1-senderid-get-200.json
@@ -1,7 +1,7 @@
 {
     "description": "Camera 1",
     "label": "Camera 1",
-    "manifest_href": "http://172.29.176.146:12345/x-nmos/node/v1.1/self/pipelinemanager/run/pipeline/1/pipel/ipp_rtptxdfb1/misc/sdp/stream.sdp",
+    "manifest_href": "http://172.29.176.146/x-manufacturer/senders/171d5c80-7fff-4c23-9383-46503eb1c63e/stream.sdp",
     "version": "1441723958:235623703",
     "flow_id": "b25d445a-20dc-4937-a8a1-5cb3d5c613ee",
     "id": "171d5c80-7fff-4c23-9383-46503eb1c63e",

--- a/examples/queryapi-v1.1-senders-get-200.json
+++ b/examples/queryapi-v1.1-senders-get-200.json
@@ -2,7 +2,7 @@
     {
         "description": "Camera 1",
         "label": "Camera 1",
-        "manifest_href": "http://172.29.80.25:12345/x-nmos/node/v1.1/self/pipelinemanager/run/pipeline/1/pipel/ipp_rtptx2701/misc/sdp/stream.sdp",
+        "manifest_href": "http://172.29.80.25/x-manufacturer/senders/4002d6b5-5775-4975-9859-5b330fcea288/stream.sdp",
         "version": "1441724086:828491206",
         "flow_id": "75bfddce-7142-4368-bb4a-8a82c837c6df",
         "id": "4002d6b5-5775-4975-9859-5b330fcea288",
@@ -18,7 +18,7 @@
     {
         "description": "Camera 2",
         "label": "Camera 2",
-        "manifest_href": "http://172.29.176.146:12345/x-nmos/node/v1.1/self/pipelinemanager/run/pipeline/1/pipel/ipp_rtptxdfb1/misc/sdp/stream.sdp",
+        "manifest_href": "http://172.29.176.146/x-manufacturer/senders/171d5c80-7fff-4c23-9383-46503eb1c63e/stream.sdp",
         "version": "1441723958:235623703",
         "flow_id": "b25d445a-20dc-4937-a8a1-5cb3d5c613ee",
         "id": "171d5c80-7fff-4c23-9383-46503eb1c63e",
@@ -33,7 +33,7 @@
     {
         "description": "Camera 2 Audio",
         "label": "Camera 2 Audio",
-        "manifest_href": "http://172.29.176.81:12345/x-nmos/node/v1.1/self/pipelinemanager/run/pipeline/1/pipel/ipp_rtptx10b7/misc/sdp/stream.sdp",
+        "manifest_href": "http://172.29.176.81/x-manufacturer/senders/bb793530-8fd7-49f9-8514-314126bbc624/stream.sdp",
         "version": "1441724039:737277493",
         "flow_id": "4ffa5719-9ab9-4395-bedb-3534fa7ba438",
         "id": "bb793530-8fd7-49f9-8514-314126bbc624",


### PR DESCRIPTION
This PR covers some errors spotted in Markdown links, and some minor clarifications within the documentation relating to Sender HREFs, order of resource registration and TXT records.