### PR TITLE
schemas: restrict formatting of interface port ID and chassis ID

### DIFF
--- a/APIs/schemas/node.json
+++ b/APIs/schemas/node.json
@@ -106,7 +106,7 @@
           }
         },
         "interfaces": {
-          "description":"Network interfaces made available to devices owned by this Node",
+          "description":"Network interfaces made available to devices owned by this Node. Port IDs and Chassis IDs are used to inform topology discovery via IS-06, and require that interfaces implement ARP at a minimum, and ideally LLDP.",
           "type": "array",
           "items": {
             "type": "object",
@@ -114,11 +114,27 @@
             "properties": {
               "chassis_id": {
                 "description": "Chassis ID of the interface, as signalled in LLDP from this node. Set to null where LLDP is unsuitable for use (ie. virtualised environments)",
-                "type": ["string", "null"]
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "pattern": "^([0-9a-f]{2}[-]){5}([0-9a-f]{2})$",
+                    "description": "When the Chassis ID is a MAC address, use this format"
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "^.+$",
+                    "description": "When the Chassis ID is anything other than a MAC address, a freeform string may be used"
+                  },
+                  {
+                    "type": "null",
+                    "description": "When the Chassis ID is unavailable it should be set to null"
+                  }
+                ]
               },
               "port_id": {
-                "description": "Port ID of the interface, as signalled in LLDP from this node. Set to interface MAC address where LLDP is unsuitable for use (ie. virtualised environments)",
-                "type": "string"
+                "description": "Port ID of the interface, as signalled in LLDP or via ARP responses from this node. Must be a MAC address",
+                "type": "string",
+                "pattern": "^([0-9a-f]{2}[-]){5}([0-9a-f]{2})$"
               },
               "name": {
                 "description": "Name of the interface (unique in scope of this node).  This attribute is used by sub-resources of this node such as senders and receivers to refer to interfaces to which they are bound.",


### PR DESCRIPTION
Schema validation modification to restrict Port IDs to be MAC addresses, and suggest formatting for Chassis IDs. Intended to match the representation agreed within the Network Control API.