### PR TITLE
[RegistrationAPI.raml]  mDNS Service Name Too Long (Addresses #34)

### DIFF
--- a/APIs/RegistrationAPI.raml
+++ b/APIs/RegistrationAPI.raml
@@ -17,7 +17,7 @@ documentation:
   - title: DNS-SD Advertisement
     content: |
       Registration APIs MUST produce an mDNS advertisement of the type \_nmos-registration.\_tcp. This MAY be accompanied by a unicast DNS announcement of the same type.
-      *note: RFC6763 Section 7.2 specifies that the maximum service name length for an mDNS advertisement is 16 characters when including the leading underscore, but "_nmos_registration" is 18 characters.*
+      *note: RFC6763 Section 7.2 specifies that the maximum service name length for an mDNS advertisement is 16 characters when including the leading underscore, but "_nmos-registration" is 18 characters.*
       <!-- TODO: Address the length of the mDNS advertisement type -->
 
       The IP address and port of the Registration API MUST be identified via the DNS-SD advertisement, with the full HTTP path then being resolved via the standard NMOS API path documentation.

--- a/APIs/RegistrationAPI.raml
+++ b/APIs/RegistrationAPI.raml
@@ -18,7 +18,7 @@ documentation:
     content: |
       Registration APIs MUST produce an mDNS advertisement of the type \_nmos-registration.\_tcp. This MAY be accompanied by a unicast DNS announcement of the same type.
       *note: RFC6763 Section 7.2 specifies that the maximum service name length for an mDNS advertisement is 16 characters when including the leading underscore, but "_nmos_registration" is 18 characters.*
-      <-- TODO! Address the length of the mDNS advertisement type -->
+      <!-- TODO: Address the length of the mDNS advertisement type -->
 
       The IP address and port of the Registration API MUST be identified via the DNS-SD advertisement, with the full HTTP path then being resolved via the standard NMOS API path documentation.
 

--- a/APIs/RegistrationAPI.raml
+++ b/APIs/RegistrationAPI.raml
@@ -17,6 +17,8 @@ documentation:
   - title: DNS-SD Advertisement
     content: |
       Registration APIs MUST produce an mDNS advertisement of the type \_nmos-registration.\_tcp. This MAY be accompanied by a unicast DNS announcement of the same type.
+      *note: RFC6763 Section 7.2 specifies that the maximum service name length for an mDNS advertisement is 16 characters when including the leading underscore, but "_nmos_registration" is 18 characters.*
+      <-- TODO! Address the length of the mDNS advertisement type -->
 
       The IP address and port of the Registration API MUST be identified via the DNS-SD advertisement, with the full HTTP path then being resolved via the standard NMOS API path documentation.
 


### PR DESCRIPTION
-  Add note that RFC 6763 specifies a max advertisement length of 16 characters but that specified length is 18 characters. 
-  Add TODO note to change this at some point

Signed-off-by: Brad Gilmer <brad@gilmer.tv>