### PR TITLE
docs: clarify trailing slash policy regarding 301 redirects

### DIFF
--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -85,7 +85,7 @@ In order to overcome shortcomings in some common libraries, the following requir
 
 * Clients performing requests using these methods MUST use URLs with no trailing slash present.
 * Servers implementing the APIs MUST correctly interpret requests using these methods to paths without trailing slashes present.
-* Servers implementing the APIs MAY correctly interpret requests using these methods to paths with trailing slashes present.
+* Servers implementing the APIs MAY correctly interpret requests using these methods to paths with trailing slashes present for backward compatibility.
 * Servers SHOULD NOT respond with 3xx codes for these request types.
 
 ### Error Codes & Responses

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -71,8 +71,22 @@ A v1.1 API response may include:
 
 ### URLs: Approach to Trailing Slashes
 
-* If a client performs a GET or HEAD request it SHOULD correctly handle a 301 response (moved permanently).
-* The client MUST follow the 301 redirect in order to retrieve the required resource.
+For consistency and in order to adhere to how these APIs are specified in RAML, the 'primary' path for every resource has the trailing slash omitted.
+
+In order to overcome shortcomings in some common libraries, the following requirements are imposed for the support of URL paths with or without trailing slashes.
+
+#### GET and HEAD Requests
+
+* Clients performing requests using these methods SHOULD correctly handle a 301 response (moved permanently).
+* When a 301 is supported, the client MUST follow the redirect in order to retrieve the required response payload.
+* Servers implementing the APIs MUST support requests using these methods to both the trailing slash and non-trailing slash path to each resource. One of these MAY produce a 301 response causing a redirect to the other if preferred.
+
+#### All Other Requests (PUT, POST, DELETE, OPTIONS etc)
+
+* Clients performing requests using these methods MUST use URLs with no trailing slash present.
+* Servers implementing the APIs MUST correctly interpret requests using these methods to paths without trailing slashes present.
+* Servers implementing the APIs MAY correctly interpret requests using these methods to paths with trailing slashes present.
+* Servers SHOULD NOT respond with 3xx codes for these request types.
 
 ### Error Codes & Responses
 


### PR DESCRIPTION
Fixes #15 