### PR TITLE
nodeapi: fix missing schema for empty object on unsubscription

### DIFF
--- a/APIs/NodeAPI.raml
+++ b/APIs/NodeAPI.raml
@@ -248,7 +248,7 @@ documentation:
         description: Request a change to a Receiver's subscription (deprecated)
         body:
           example: !include ../examples/nodeapi-v1.1-senderid-get-200.json
-          schema: Sender
+          schema: !include schemas/nodeapi-receiver-target.json
         responses:
           202:
             body:

--- a/APIs/schemas/nodeapi-receiver-target.json
+++ b/APIs/schemas/nodeapi-receiver-target.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes the possible requests to a Node's Receiver target resource",
+  "title": "Receiver target resource",
+  "oneOf": [
+    { "$ref": "sender.json" },
+    {
+      "type": "object",
+      "description": "Describes an empty object",
+      "title": "Empty object schema",
+      "additionalProperties": false,
+      "required": [
+      ],
+      "properties": {
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #37 