### PR TITLE
docs: add note on use of the path returned by ws_href

### DIFF
--- a/docs/4.2. Behaviour - Querying.md
+++ b/docs/4.2. Behaviour - Querying.md
@@ -8,6 +8,8 @@ The Query API provides a read-only interface to the Nodes and their sub-resource
 
 In order to connect to a websocket, a client must first request a subscription of a particular type and with particular query parameters as defined in the [Query API](../APIs/QueryAPI.raml) subscriptions documentation.
 
+There is no mandated URL base path for servers to use when creating websocket connections. Instead clients should observe the value of 'ws_href' which is returned by their subscription request in order to identify what to connect to.
+
 Websockets created for specific clients will be cleaned up automatically if they disconnect.
 
 Connection upgrade procedures permitting an existing HTTP query to transition to a websocket are not currently supported, but may be in the future.


### PR DESCRIPTION
Replaces the solution proposed in #45 to resolve #33