### PR TITLE
docs: fix minor conflict in recovery guidance for unplugged cables

### DIFF
--- a/docs/4.1. Behaviour - Registration.md
+++ b/docs/4.1. Behaviour - Registration.md
@@ -73,7 +73,7 @@ It is expected that some types of Node will be unable to unregister themselves i
 
 ### Network Disconnect / Reconnect
 
-If a network cable is temporarily unplugged, dependent on the time for which it remains unplugged and the settings used by the registry, the Node may or may not have remained registered when it comes back online. In order to confirm this, when a Node comes back onto the network it should carry on as if the connection had not been interrupted and issue heartbeats. If an error response is returned for these heartbeats the Node should proceed as described in the 'Error Conditions' section below.
+If a network cable is temporarily unplugged, dependent on the time for which it remains unplugged and the settings used by the registry, the Node may or may not have remained registered. When the Node comes back onto the network it should proceed as described in the 'Error Conditions' section below covering an inability to connect and timeouts.
 
 ## Error Conditions
 
@@ -91,7 +91,7 @@ A 400 error indicates a client error which is likely to be the result of a valid
 
 A 404 error on heartbeat indicates that the Node performing the heartbeat is not known to the Registration API. This could be as a result of a number of missed heartbeats which triggered garbage collection in the Registration API. On encountering this code, a Node must re-register each of its resources with the Registration API in order.
 
-### Node Encounters HTTP 500 (or other 5xx), Inability To Connect, Or A Timeout On Heartbeat
+### Node Encounters HTTP 500 (or other 5xx), Inability To Connect, Or A Timeout
 
 A 500 error, inability to connect or a timeout indicates a server side or connectivity issue. As this issue may affect just one Registration API in a cluster, it is recommended that clients identify another Registration API to use from their discovered list. The first interaction with a new Registration API in this case should be a heartbeat to confirm whether the Node is still present in the registry.
 


### PR DESCRIPTION
Fixes a minor conflict in suggested behaviour when a Node knows about a loss of network connection vs. when it is an issue more remote from the Node. Originally reported by @garethsb-sony 