### PR TITLE
interface_bindings: re-word to be clear about single interface 2022-7

### DIFF
--- a/APIs/schemas/receiver_core.json
+++ b/APIs/schemas/receiver_core.json
@@ -40,7 +40,7 @@
           "format": "uri"
         },
         "interface_bindings": {
-          "description": "Binding of Receiver ingress ports to interfaces on the parent Node. Should contain a single network interface unless a redundancy mechanism such as ST.2022-7 is in use, in which case each 'leg' should have a matching interface listed.",
+          "description": "Binding of Receiver ingress ports to interfaces on the parent Node. Should contain a single network interface unless a redundancy mechanism such as ST.2022-7 is in use, in which case each 'leg' should have its matching interface listed. Where the redundancy mechanism receives more than one copy of the stream via the same interface, that interface should be listed a corresponding number of times.",
           "type": "array",
           "items": {
             "type":"string"

--- a/APIs/schemas/sender.json
+++ b/APIs/schemas/sender.json
@@ -59,7 +59,7 @@
           "format": "uri"
         },
         "interface_bindings": {
-          "description": "Binding of Sender egress ports to interfaces on the parent Node. Should contain a single network interface unless a redundancy mechanism such as ST.2022-7 is in use, in which case each 'leg' should have a matching interface listed.",
+          "description": "Binding of Sender egress ports to interfaces on the parent Node. Should contain a single network interface unless a redundancy mechanism such as ST.2022-7 is in use, in which case each 'leg' should have its matching interface listed. Where the redundancy mechanism sends more than one copy of the stream via the same interface, that interface should be listed a corresponding number of times.",
           "type": "array",
           "items": {
             "type":"string"


### PR DESCRIPTION
Clarifies language around usage of interface_bindings when using 2022-7 in single interface mode.

This ensures it's clear that the number of entries in interface_bindings should always match the number of entries in IS-05's transport_params array.