### PR TITLE
docs: remove requirement for manifest_href to have .sdp extension

### DIFF
--- a/docs/2.3. APIs - Server Side Implementation Notes.md
+++ b/docs/2.3. APIs - Server Side Implementation Notes.md
@@ -25,4 +25,4 @@ Where 'href' or 'host' attributes are specified in the APIs, it is strongly reco
 
 ## Node API Senders: Use with RTP
 
-When using RTP for a sender, the 'manifest_href' must be an HTTP-accessible reference to an SDP file. As-per [RFC 4566](https://tools.ietf.org/html/rfc4566), SDP files advertised via web services should use a MIME type of 'application/sdp' and a file extension of '.sdp'.
+When using RTP for a sender, the 'manifest_href' must be an HTTP-accessible reference to an SDP file. As-per [RFC 4566](https://tools.ietf.org/html/rfc4566), SDP files advertised via web services should use a MIME type of 'application/sdp'.


### PR DESCRIPTION
Resolves #63 