### PR TITLE
dns-sd: add a new service type to resolve Reg API length issue

### DIFF
--- a/APIs/RegistrationAPI.raml
+++ b/APIs/RegistrationAPI.raml
@@ -15,9 +15,10 @@ documentation:
       The Registration API is exposed by NMOS discovery Nodes. It is used to publish data to the distributed registry, which can then be queried via the Query API. In smaller deployments where no distributed registry is available, the Registration API is not used and discovery responsibilities fall to individual Nodes which choose to implement Peer to Peer specification. The Registration API is a Write Only API.
   - title: DNS-SD Advertisement
     content: |
-      Registration APIs MUST produce an mDNS advertisement of the type \_nmos-registration.\_tcp. This MAY be accompanied by a unicast DNS announcement of the same type.
+      Registration APIs MUST produce an mDNS advertisement of the type \_nmos-register.\_tcp. This MAY be accompanied by a unicast DNS announcement of the same type.
+
+      Registration APIs supporting versions 'v1.2' and below MUST additionally produce an mDNS advertisement of type \_nmos-registration.\_tcp. This MAY be accompanied by a unicast DNS announcement of the same type.
       *note: RFC6763 Section 7.2 specifies that the maximum service name length for an mDNS advertisement is 16 characters when including the leading underscore, but "_nmos-registration" is 18 characters.*
-      <!-- TODO: Address the length of the mDNS advertisement type -->
 
       The IP address and port of the Registration API MUST be identified via the DNS-SD advertisement, with the full HTTP path then being resolved via the standard NMOS API path documentation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This document provides an overview of changes between released versions of this 
 ## Release (unreleased)
 * Under active development
 
+* Replace DNS-SD service type for Registration API
 * Permit deprecated Node API connection management to not be implemented
 * Add explicit requirements for 501 responses when features are not implemented
 * Add support for future device and transport types

--- a/docs/3.0. Discovery.md
+++ b/docs/3.0. Discovery.md
@@ -7,8 +7,12 @@ NMOS Discovery makes use of the DNS Service Discovery protocol as described in [
 Three DNS-SD service types are defined by this specification:
 
 * **_nmos-node._tcp:** A logical host which advertises a Node API.
-* **_nmos-registration._tcp** A logical host which advertises a Registration API.
+* **_nmos-register._tcp** A logical host which advertises a Registration API.
 * **_nmos-query._tcp** A logical host which advertises a Query API.
+
+The following is an additional DNS-SD service type required to support older versions of the Registration API (v1.2 and below):
+
+* **_nmos-registration._tcp** A logical host which advertises a Registration API.
 
 Advertisements of the above types are accompanied by DNS TXT records as specified within the API RAML documentation.
 
@@ -19,8 +23,8 @@ Dependent on the architecture of a network, it may make sense to use one or both
 When performing a DNS-SD browse, clients should proceed as follows:
 
 1. Identify whether the client has been configured with DNS server addresses and a default search domain either manually or automatically via DHCP.
-2. If such configuration exists, perform a unicast DNS browse for services of type '\_nmos-registration.\_tcp' via the search domain.
-3. Perform a multicast DNS browse for services of type '\_nmos-registration.\_tcp' in the '.local' domain.
+2. If such configuration exists, perform a unicast DNS browse for services of type '\_nmos-register.\_tcp' via the search domain.
+3. Perform a multicast DNS browse for services of type '\_nmos-register.\_tcp' in the '.local' domain.
 4. Merge the results of the two operations into a list, sorted using the priority values associated with each record.
 5. The above list should be maintained via the methods defined by the DNS-SD specification.
 

--- a/docs/3.0. Discovery.md
+++ b/docs/3.0. Discovery.md
@@ -25,7 +25,7 @@ When performing a DNS-SD browse, clients should proceed as follows:
 1. Identify whether the client has been configured with DNS server addresses and a default search domain either manually or automatically via DHCP.
 2. If such configuration exists, perform a unicast DNS browse for services of type '\_nmos-register.\_tcp' via the search domain.
 3. Perform a multicast DNS browse for services of type '\_nmos-register.\_tcp' in the '.local' domain.
-4. Merge the results of the two operations into a list, sorted using the priority values associated with each record.
+4. Merge the results of the two operations into a list, sorted using the priority values associated with each record, and discarding any advertisements which do not meet the Node's requirements.
 5. The above list should be maintained via the methods defined by the DNS-SD specification.
 
 ## Implementation Notes

--- a/docs/3.1. Discovery - Registered Operation.md
+++ b/docs/3.1. Discovery - Registered Operation.md
@@ -7,7 +7,8 @@ This document describes usage of NMOS APIs for discovery in cases where where a 
 ## Registration
 
 1. Node comes online
-2. Node scans for an active Registration API on the network using unicast and/or multicast DNS service discovery (type '\_nmos-registration.\_tcp')
+2. Node scans for an active Registration API on the network using unicast and/or multicast DNS service discovery (type '\_nmos-register.\_tcp')
+   *  Nodes which support v1.2 and earlier versions MUST additionally browse for the deprecated service type '\_nmos-registration.\_tcp'.
 3. Given multiple returned Registration APIs, the Node orders these based on their advertised priority (TXT pri), filtering out any APIs which do not support its required API version and protocol (TXT api_ver and api_proto).
 4. The Node selects a Registration API to use based on the priority, and a random selection if multiple Registration APIs with the same priority are identified (see mechanism specified in [RFC 2782](https://tools.ietf.org/html/rfc2782)).
 5. Node proceeds to register its resources with the selected Registration API.
@@ -15,6 +16,8 @@ This document describes usage of NMOS APIs for discovery in cases where where a 
 If the chosen Registration API does not respond correctly at any time, another Registration API should be selected from the discovered list. Should no further Registration APIs be available or TTLs on advertised services expired, a re-query may be performed.
 
 If no Registration APIs are advertised on a network, the Node should assume peer to peer operation unless configured otherwise. The required TXT record advertisements for this mode are described in the [Node API](../APIs/NodeAPI.raml).
+
+See the [Upgrade Path](6.0.%20Upgrade%20Path.md) for further details on supporting multiple versions simultaneously.
 
 ## Querying
 

--- a/docs/3.1. Discovery - Registered Operation.md
+++ b/docs/3.1. Discovery - Registered Operation.md
@@ -10,6 +10,7 @@ This document describes usage of NMOS APIs for discovery in cases where where a 
 2. Node scans for an active Registration API on the network using unicast and/or multicast DNS service discovery (type '\_nmos-register.\_tcp')
    *  Nodes which support v1.2 and earlier versions MUST additionally browse for the deprecated service type '\_nmos-registration.\_tcp'.
 3. Given multiple returned Registration APIs, the Node orders these based on their advertised priority (TXT pri), filtering out any APIs which do not support its required API version and protocol (TXT api_ver and api_proto).
+   *  Where a Node supports multiple API versions simultaneously, see the [Upgrade Path](6.0.%20Upgrade%20Path.md) for additional requirements in filtering the discovered API list.
 4. The Node selects a Registration API to use based on the priority, and a random selection if multiple Registration APIs with the same priority are identified (see mechanism specified in [RFC 2782](https://tools.ietf.org/html/rfc2782)).
 5. Node proceeds to register its resources with the selected Registration API.
 
@@ -17,13 +18,12 @@ If the chosen Registration API does not respond correctly at any time, another R
 
 If no Registration APIs are advertised on a network, the Node should assume peer to peer operation unless configured otherwise. The required TXT record advertisements for this mode are described in the [Node API](../APIs/NodeAPI.raml).
 
-See the [Upgrade Path](6.0.%20Upgrade%20Path.md) for further details on supporting multiple versions simultaneously.
-
 ## Querying
 
 1. Node (or control interface) comes online
 2. Node scans for an active Query API on the network using unicast and/or multicast DNS service discovery (type '\_nmos-query.\_tcp')
 3. Given multiple returned Query APIs, the Node orders these based on their advertised priority (TXT pri), filtering out any APIs which do not support its required API version and protocol (TXT api_ver and api_proto).
+   *  Where a Node supports multiple API versions simultaneously, see the [Upgrade Path](6.0.%20Upgrade%20Path.md) for additional requirements in filtering the discovered API list.
 4. The Node selects a Query API to use based on the priority, and a random selection if multiple Query APIs with the same priority are identified (see mechanism specified in [RFC 2782](https://tools.ietf.org/html/rfc2782)).
 5. Node proceeds to request data as required from the selected Query API.
 

--- a/docs/3.1. Discovery - Registered Operation.md
+++ b/docs/3.1. Discovery - Registered Operation.md
@@ -11,7 +11,7 @@ This document describes usage of NMOS APIs for discovery in cases where where a 
    *  Nodes which support v1.2 and earlier versions MUST additionally browse for the deprecated service type '\_nmos-registration.\_tcp'.
 3. Given multiple returned Registration APIs, the Node orders these based on their advertised priority (TXT pri), filtering out any APIs which do not support its required API version and protocol (TXT api_ver and api_proto).
    *  Where a Node supports multiple API versions simultaneously, see the [Upgrade Path](6.0.%20Upgrade%20Path.md) for additional requirements in filtering the discovered API list.
-4. The Node selects a Registration API to use based on the priority, and a random selection if multiple Registration APIs with the same priority are identified (see mechanism specified in [RFC 2782](https://tools.ietf.org/html/rfc2782)).
+4. The Node selects a Registration API to use based on the priority, and a random selection if multiple Registration APIs of the same API version with the same priority are identified.
 5. Node proceeds to register its resources with the selected Registration API.
 
 If the chosen Registration API does not respond correctly at any time, another Registration API should be selected from the discovered list. Should no further Registration APIs be available or TTLs on advertised services expired, a re-query may be performed.
@@ -24,7 +24,7 @@ If no Registration APIs are advertised on a network, the Node should assume peer
 2. Node scans for an active Query API on the network using unicast and/or multicast DNS service discovery (type '\_nmos-query.\_tcp')
 3. Given multiple returned Query APIs, the Node orders these based on their advertised priority (TXT pri), filtering out any APIs which do not support its required API version and protocol (TXT api_ver and api_proto).
    *  Where a Node supports multiple API versions simultaneously, see the [Upgrade Path](6.0.%20Upgrade%20Path.md) for additional requirements in filtering the discovered API list.
-4. The Node selects a Query API to use based on the priority, and a random selection if multiple Query APIs with the same priority are identified (see mechanism specified in [RFC 2782](https://tools.ietf.org/html/rfc2782)).
+4. The Node selects a Query API to use based on the priority, and a random selection if multiple Query APIs of the same version with the same priority are identified.
 5. Node proceeds to request data as required from the selected Query API.
 
 If the chosen Query API does not respond correctly at any time, another Query API should be selected from the discovered list. Should no further Query APIs be available or TTLs on advertised services expired, a re-query may be performed.

--- a/docs/4.1. Behaviour - Registration.md
+++ b/docs/4.1. Behaviour - Registration.md
@@ -15,7 +15,7 @@ The following behaviour assumes a Node with a single network interface for all t
 1. A Node is connected to the network
 2. The Node runs an HTTP accessible Node API.
 3. The Node produces an mDNS advertisement of type '\_nmos-node.\_tcp' in the '.local' domain as specified in [Node API](../APIs/NodeAPI.raml).
-4. The Node performs a DNS-SD browse for services of type '\_nmos-registration.\_tcp' as specified in [Discovery: Registered Operation](3.1.%20Discovery%20-%20Registered%20Operation.md).
+4. The Node performs a DNS-SD browse for services of type '\_nmos-register.\_tcp' as specified in [Discovery: Registered Operation](3.1.%20Discovery%20-%20Registered%20Operation.md).
 5. The Node registers itself with the Registration API by taking the object it holds under the Node API's /self resource and POSTing this to the Registration API.
 6. The Node persists itself in the registry by issuing heartbeats as below.
 7. The Node registers its other resources (from /devices, /sources etc) with the Registration API. Note that resources must be registered in the correct order, such that a Receiver which references a device_id is registered after that corresponding Device (for example).

--- a/docs/6.0. Upgrade Path.md
+++ b/docs/6.0. Upgrade Path.md
@@ -8,19 +8,19 @@ API versioning is specified in the [APIs](2.0.%20APIs.md) documentation, with pr
 
 ## Requirements for Nodes (Node APIs)
 
-Implementers of the Node API must support at least one API version, and may support more than one at a time. Note however that a Node must only perform interactions with a Registration API at a single version. Nodes implementing multiple API versions may provide a user-configurable choice for which API version to register and/or query using. Otherwise it is expected that the Node will select a Registration API which supports the highest API version which the Node also supports. The API version should be selected before considering the Registration API's configured \'priority\'.
+Implementers of the Node API MUST support at least one API version, and MAY support more than one at a time. Note however that a Node MUST only perform interactions with a Registration API at a single version. Nodes implementing multiple API versions MAY provide a user-configurable choice for which API version to register and/or query using. Otherwise it is expected that the Node will select a Registration API which supports the highest API version which the Node also supports. The API version should be selected before considering the Registration API's configured \'priority\'.
 
 Registrations with a Registration API must only proceed if the Node API version implemented exactly matches the API version used by the Registration API.
 
-Where a Node implements version v1.2 or below, it must browse for both the \'_nmos-register._tcp\' DNS-SD service type, and the legacy \'_nmos-registration._tcp\' DNS-SD service type in order to retrieve the full list of available Registration APIs. De-duplication should be performed against this returned list.
+Where a Node implements version v1.2 or below, it MUST browse for both the \'\_nmos-register.\_tcp\' DNS-SD service type, and the legacy \'\_nmos-registration.\_tcp\' DNS-SD service type in order to retrieve the full list of available Registration APIs. De-duplication SHOULD be performed against this returned list.
 
 ## Requirements for Registries (Registration and Query APIs)
 
-Implementers of the Registration and Query API must support at least one API version. It is however strongly recommended that Registration and Query APIs fully support at least two and preferably more consecutive API versions (if released). In doing so, facilities which include a large number of Nodes may stagger their equipment upgrades whilst maintaining compatibility with a single registry.
+Implementers of the Registration and Query API MUST support at least one API version. It is however strongly recommended that Registration and Query APIs fully support at least two and preferably more consecutive API versions (if released). In doing so, facilities which include a large number of Nodes can stagger their equipment upgrades whilst maintaining compatibility with a single registry.
 
-When supporting multiple API versions, Query APIs must provide translations of resources for backwards compatibility. For example, if the registry contains a mixture of v1.0 and v1.1 resources, a v1.0 Query API must provide a response containing all of these resources by removing keys from v1.1 resources which are not present in v1.0.
+When supporting multiple API versions, Query APIs MUST provide translations of resources for backwards compatibility. For example, if the registry contains a mixture of v1.0 and v1.1 resources, a v1.0 Query API is required to provide a response containing all of these resources by removing keys from v1.1 resources which are not present in v1.0.
 
-Query APIs are not required to provide for forwards compatibility as it may be impossible to generate data for new attributes in schemas. Query APIs should however allow clients to request older data than the requested minor API version by using the ?query.downgrade=<version> query parameter (see Query API documentation for examples).
+Query APIs are not required to provide for forwards compatibility as it may be impossible to generate data for new attributes in schemas. Query APIs SHOULD however allow clients to request older data than the requested minor API version by using the ?query.downgrade=<version> query parameter (see Query API documentation for examples).
 
 ## Performing Upgrades
 

--- a/docs/6.0. Upgrade Path.md
+++ b/docs/6.0. Upgrade Path.md
@@ -12,6 +12,8 @@ Implementers of the Node API must support at least one API version, and may supp
 
 Registrations with a Registration API must only proceed if the Node API version implemented exactly matches the API version used by the Registration API.
 
+Where a Node implements version v1.2 or below, it must browse for both the \'_nmos-register._tcp\' DNS-SD service type, and the legacy \'_nmos-registration._tcp\' DNS-SD service type in order to retrieve the full list of available Registration APIs. De-duplication should be performed against this returned list.
+
 ## Requirements for Registries (Registration and Query APIs)
 
 Implementers of the Registration and Query API must support at least one API version. It is however strongly recommended that Registration and Query APIs fully support at least two and preferably more consecutive API versions (if released). In doing so, facilities which include a large number of Nodes may stagger their equipment upgrades whilst maintaining compatibility with a single registry.

--- a/docs/6.0. Upgrade Path.md
+++ b/docs/6.0. Upgrade Path.md
@@ -8,7 +8,7 @@ API versioning is specified in the [APIs](2.0.%20APIs.md) documentation, with pr
 
 ## Requirements for Nodes (Node APIs)
 
-Implementers of the Node API must support at least one API version, and may support more than one at a time. Note however that a Node must only perform interactions with a Registration API at a single version. Nodes implementing multiple API versions may provide a user-configurable choice for which API version to register and/or query using.
+Implementers of the Node API must support at least one API version, and may support more than one at a time. Note however that a Node must only perform interactions with a Registration API at a single version. Nodes implementing multiple API versions may provide a user-configurable choice for which API version to register and/or query using. Otherwise it is expected that the Node will select a Registration API which supports the highest API version which the Node also supports. The API version should be selected before considering the Registration API's configured \'priority\'.
 
 Registrations with a Registration API must only proceed if the Node API version implemented exactly matches the API version used by the Registration API.
 


### PR DESCRIPTION
A potential solution to the DNS-SD service name length issue, which would take effect from v1.3 onwards. Requires further discussion.

Resolves #34 