### PR TITLE
Removing locking of transport and device types to IS-04 versioning

### DIFF
--- a/APIs/schemas/device.json
+++ b/APIs/schemas/device.json
@@ -20,10 +20,7 @@
           "type": "string",
           "oneOf": [
             {
-              "enum": [
-                "urn:x-nmos:device:generic",
-                "urn:x-nmos:device:pipeline"
-              ]
+              "pattern": "^urn:x-nmos:device:"
             },
             {
               "not": {

--- a/APIs/schemas/receiver_core.json
+++ b/APIs/schemas/receiver_core.json
@@ -24,12 +24,7 @@
           "type": "string",
           "oneOf": [
             {
-              "enum": [
-                "urn:x-nmos:transport:rtp",
-                "urn:x-nmos:transport:rtp.ucast",
-                "urn:x-nmos:transport:rtp.mcast",
-                "urn:x-nmos:transport:dash"
-              ]
+              "pattern": "^urn:x-nmos:transport:"
             },
             {
               "not": {

--- a/APIs/schemas/sender.json
+++ b/APIs/schemas/sender.json
@@ -33,12 +33,7 @@
           "type": "string",
           "oneOf": [
             {
-              "enum": [
-                "urn:x-nmos:transport:rtp",
-                "urn:x-nmos:transport:rtp.ucast",
-                "urn:x-nmos:transport:rtp.mcast",
-                "urn:x-nmos:transport:dash"
-              ]
+              "pattern": "^urn:x-nmos:transport:"
             },
             {
               "not": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This document provides an overview of changes between released versions of this 
 ## Release (unreleased)
 * Under active development
 
+* Add support for future device and transport types
+
 ## Release v1.2
 * Add network interfaces and bindings to Nodes, Senders and Receivers
 * Deprecate native Node API connection management interface

--- a/docs/2.1. APIs - Common Keys.md
+++ b/docs/2.1. APIs - Common Keys.md
@@ -39,6 +39,8 @@ Query API clients MUST be tolerant to the presence of formats not yet defined he
 
 A URN describing the protocol used to send data (video, audio, data etc.) over a network.
 
+Note: From v1.3 onwards, permitted transport types are not versioned and are instead defined via the [NMOS Parameter Registers](https://github.com/AMWA-TV/nmos-parameter-registers). Prior to v1.3, the following table applies.
+
 | **Permitted Value**            | **Valid From API Version** |
 |--------------------------------|----------------------------|
 | urn:x-nmos:transport:rtp       | v1.0                       |
@@ -48,7 +50,7 @@ A URN describing the protocol used to send data (video, audio, data etc.) over a
 
 For example, an RTP Transmitter sending to a multicast group should use the transport 'urn:x-nmos:transport:rtp.mcast', but a receiver supporting both unicast and multicast should present the transport 'urn:x-nmos:transport:rtp' to indicate its less restrictive state.
 
-Manufacturers MAY use their own namespaces to indicate transports which are not defined within the NMOS namespace at a particular API version, but should support be added in a future version the NMOS variant MUST be used when upgrading to that API version.
+Manufacturers MAY use their own namespaces to indicate transports which are not currently defined within the NMOS namespace.
 
 As with formats (described above), subclassifications of these URNs must be recognised correctly as members of these top level categories.
 
@@ -71,6 +73,8 @@ A set of keys and values providing a means to filter resources based on particul
 
 A URN describing the role which a Device has within the production environment (such as camera, mixer, tally light etc.).
 
+Note: From v1.3 onwards, permitted device types are not versioned and are instead defined via the [NMOS Parameter Registers](https://github.com/AMWA-TV/nmos-parameter-registers). Prior to v1.3, the following table applies.
+
 | **Permitted Value**        | **Valid From API Version** |
 |----------------------------|----------------------------|
 | urn:x-nmos:device:generic  | v1.0                       |
@@ -78,4 +82,4 @@ A URN describing the role which a Device has within the production environment (
 
 As with formats (described above), subclassifications of these URNs must be recognised correctly as members of these top level categories.
 
-Manufacturers MAY use their own namespaces to indicate device types which are not defined within the NMOS namespace at a particular API version, but should support be added in a future version the NMOS variant MUST be used when upgrading to that API version.
+Manufacturers MAY use their own namespaces to indicate device types which are not currently defined within the NMOS namespace.


### PR DESCRIPTION
This is part one of two modifications required in order to support IS-07 in IS-04 v1.3.