### PR TITLE
registration: add informative note on fix for over-sized service type

### DIFF
--- a/APIs/RegistrationAPI.raml
+++ b/APIs/RegistrationAPI.raml
@@ -16,8 +16,7 @@ documentation:
   - title: DNS-SD Advertisement
     content: |
       Registration APIs MUST produce an mDNS advertisement of the type \_nmos-registration.\_tcp. This MAY be accompanied by a unicast DNS announcement of the same type.
-      *note: RFC6763 Section 7.2 specifies that the maximum service name length for an mDNS advertisement is 16 characters when including the leading underscore, but "_nmos-registration" is 18 characters.*
-      <!-- TODO: Address the length of the mDNS advertisement type -->
+      *note: RFC6763 Section 7.2 specifies that the maximum service name length for an mDNS advertisement is 16 characters when including the leading underscore, but "_nmos-registration" is 18 characters. Implementers of IS-04 v1.2 and below are advised to consult the v1.3 documentation for an additional service type which can be used to resolve this issue. Use of this additional service type requires that any v1.2 and earlier Nodes are also updated to support browsing for it.*
 
       The IP address and port of the Registration API MUST be identified via the DNS-SD advertisement, with the full HTTP path then being resolved via the standard NMOS API path documentation.
 

--- a/docs/3.0. Discovery.md
+++ b/docs/3.0. Discovery.md
@@ -12,6 +12,8 @@ Three DNS-SD service types are defined by this specification:
 
 Advertisements of the above types are accompanied by DNS TXT records as specified within the API RAML documentation.
 
+Implementers of IS-04 v1.2 and below are advised to consult the v1.3 documentation for an additional Registration API service type which can be supported in order to overcome the over-sized \_nmos-registration.\_tcp name.
+
 ## Unicast vs. Multicast DNS-SD
 
 Dependent on the architecture of a network, it may make sense to use one or both of unicast or multicast DNS for discovery. 'Registered' mode may support both of these cases, however 'Peer to Peer' mode only supports multicast operation. Nodes may optionally be configured to support just one of unicast or multicast service discovery, however it is recommended that both are used by default in order to make initial device configuration as configuration free as possible.


### PR DESCRIPTION
Adds a note to the documentation of release spec versions to indicate how issues with the over-sized _nmos-registration._tcp name can be resolved.

Do not merge this until v1.3 of IS-04 (which includes the resolution) has been released.