### PR TITLE
docs: clarify definition of a URN subclassification

### DIFF
--- a/docs/2.1. APIs - Common Keys.md
+++ b/docs/2.1. APIs - Common Keys.md
@@ -82,12 +82,21 @@ See [Use of URNs](#use-of-urns) below for additional requirements regarding thei
 
 All Uniform Resource Names (URNs) specified within the scope of the NMOS specifications MUST use the namespace 'urn:x-nmos:'. Manufacturers MAY use their own namespaces to indicate values of URN which are not currently defined within the NMOS namespace.
 
-Where a URN begins 'urn:x-nmos:' it MAY include one or more 'subclassifications'. Subclassifications are defined as the portion of the URN which follows the first occurrence of a '.'. By convention, URNs which begin 'urn:x-nmos:' will never include a further ':' after the first occurrence of a '.'.
+Where a URN begins 'urn:x-nmos:' it MUST use the following construction:
+*   The 'root' of the URN is entirely delimited by ':' characters
+*   The URN MAY include one or more 'subclassifications'
+*   The URN MAY include a version number
 
-For example, the URN 'urn:x-nmos:transport:rtp' above has two subclassifications of 'ucast' and 'mcast'.
+Subclassifications are defined as the portion of the URN which follows the first occurrence of a '.', but prior to any '/' character. By convention, URNs which begin 'urn:x-nmos:' will never include a further ':' after the first occurrence of a '.'.
+
+For example, the URN root 'urn:x-nmos:transport:rtp' above has two subclassifications of 'ucast' and 'mcast'.
 
 API clients interpreting URNs MUST correctly recognise any as-yet undefined subclassifications as being associated with the URN root which appears prior to the first '.' character.
 
 For example, if filtering by the format 'urn:x-nmos:format:video', the filter is required to include any as-yet undefined subclassifications such as 'urn:x-nmos:format:video.raw'.
+
+Versions are defined as the portion of the URN which follows the first occurrence of a '/', up to and including the remainder of the URN. Any '.' characters after this point indicate a version delimiter.
+
+For example, the URN 'urn:x-nmos:control:sr-ctrl/v1.0' can be separated into a root 'urn:x-nmos:control:sr-ctrl' and version 'v1.0'.
 
 Query API clients MUST be tolerant to URNs which have not yet been defined, but which may be added in later API versions.

--- a/docs/2.1. APIs - Common Keys.md
+++ b/docs/2.1. APIs - Common Keys.md
@@ -83,7 +83,7 @@ See [Use of URNs](#use-of-urns) below for additional requirements regarding thei
 All Uniform Resource Names (URNs) specified within the scope of the NMOS specifications MUST use the namespace 'urn:x-nmos:'. Manufacturers MAY use their own namespaces to indicate values of URN which are not currently defined within the NMOS namespace.
 
 Where a URN begins 'urn:x-nmos:' it MUST use the following construction:
-*   The 'root' of the URN is entirely delimited by ':' characters
+*   The URN 'base' is a sequence of one or more names delimited by ':' characters, including the namespace
 *   The URN MAY include one or more 'subclassifications'
 *   The URN MAY include a version number
 
@@ -95,7 +95,7 @@ API clients interpreting URNs MUST correctly recognise any as-yet undefined subc
 
 For example, if filtering by the format 'urn:x-nmos:format:video', the filter is required to include any as-yet undefined subclassifications such as 'urn:x-nmos:format:video.raw'.
 
-Versions are defined as the portion of the URN which follows the first occurrence of a '/', up to and including the remainder of the URN. Any '.' characters after this point indicate a version delimiter.
+Versions are defined as the portion of the URN which follows the first occurrence of a '/', up to and including the remainder of the URN. Any '.' characters after this point indicate a version delimiter. By convention, URNS which begin 'urn:x-nmos:' will format the version as 'v<#MAJOR>.<#MINOR>' and should be handled as specified in [APIs](2.0.%20APIs.md).
 
 For example, the URN 'urn:x-nmos:control:sr-ctrl/v1.0' can be separated into a root 'urn:x-nmos:control:sr-ctrl' and version 'v1.0'.
 

--- a/docs/2.1. APIs - Common Keys.md
+++ b/docs/2.1. APIs - Common Keys.md
@@ -89,14 +89,14 @@ Where a URN begins 'urn:x-nmos:' it MUST use the following construction:
 
 Subclassifications are defined as the portion of the URN which follows the first occurrence of a '.', but prior to any '/' character. By convention, URNs which begin 'urn:x-nmos:' will never include a further ':' after the first occurrence of a '.'.
 
-For example, the URN root 'urn:x-nmos:transport:rtp' above has two subclassifications of 'ucast' and 'mcast'.
+For example, the URN base 'urn:x-nmos:transport:rtp' above has two subclassifications of 'ucast' and 'mcast'.
 
-API clients interpreting URNs MUST correctly recognise any as-yet undefined subclassifications as being associated with the URN root which appears prior to the first '.' character.
+API clients interpreting URNs MUST correctly recognise any as-yet undefined subclassifications as being associated with the URN base which appears prior to the first '.' character.
 
 For example, if filtering by the format 'urn:x-nmos:format:video', the filter is required to include any as-yet undefined subclassifications such as 'urn:x-nmos:format:video.raw'.
 
 Versions are defined as the portion of the URN which follows the first occurrence of a '/', up to and including the remainder of the URN. Any '.' characters after this point indicate a version delimiter. By convention, URNS which begin 'urn:x-nmos:' will format the version as 'v<#MAJOR>.<#MINOR>' and should be handled as specified in [APIs](2.0.%20APIs.md).
 
-For example, the URN 'urn:x-nmos:control:sr-ctrl/v1.0' can be separated into a root 'urn:x-nmos:control:sr-ctrl' and version 'v1.0'.
+For example, the URN 'urn:x-nmos:control:sr-ctrl/v1.0' can be separated into a base 'urn:x-nmos:control:sr-ctrl' and version 'v1.0'.
 
 Query API clients MUST be tolerant to URNs which have not yet been defined, but which may be added in later API versions.

--- a/docs/2.1. APIs - Common Keys.md
+++ b/docs/2.1. APIs - Common Keys.md
@@ -31,9 +31,7 @@ A URN describing the data format of a video, audio or data flow.
 | urn:x-nmos:format:data  | v1.0                       |
 | urn:x-nmos:format:mux   | v1.1                       |
 
-API clients interpreting these URNs MUST correctly recognise subclassifications of these formats which may be added in the future. For example, if filtering by the type 'urn:x-nmos:format:video', the filter must include subclassifications such as 'urn:x-nmos:format:video.raw').
-
-Query API clients MUST be tolerant to the presence of formats not yet defined here which may be added in later API versions.
+See [Use of URNs](#use-of-urns) below for additional requirements regarding their handling.
 
 ## Transport
 
@@ -50,9 +48,7 @@ Note: From v1.3 onwards, permitted transport types are not versioned and are ins
 
 For example, an RTP Transmitter sending to a multicast group should use the transport 'urn:x-nmos:transport:rtp.mcast', but a receiver supporting both unicast and multicast should present the transport 'urn:x-nmos:transport:rtp' to indicate its less restrictive state.
 
-Manufacturers MAY use their own namespaces to indicate transports which are not currently defined within the NMOS namespace.
-
-As with formats (described above), subclassifications of these URNs must be recognised correctly as members of these top level categories.
+See [Use of URNs](#use-of-urns) below for additional requirements regarding their handling.
 
 ## Tags
 
@@ -80,6 +76,18 @@ Note: From v1.3 onwards, permitted device types are not versioned and are instea
 | urn:x-nmos:device:generic  | v1.0                       |
 | urn:x-nmos:device:pipeline | v1.0                       |
 
-As with formats (described above), subclassifications of these URNs must be recognised correctly as members of these top level categories.
+See [Use of URNs](#use-of-urns) below for additional requirements regarding their handling.
 
-Manufacturers MAY use their own namespaces to indicate device types which are not currently defined within the NMOS namespace.
+## Use of URNs
+
+All Uniform Resource Names (URNs) specified within the scope of the NMOS specifications MUST use the namespace 'urn:x-nmos:'. Manufacturers MAY use their own namespaces to indicate values of URN which are not currently defined within the NMOS namespace.
+
+Where a URN begins 'urn:x-nmos:' it MAY include one or more 'subclassifications'. Subclassifications are defined as the portion of the URN which follows the first occurrence of a '.'. By convention, URNs which begin 'urn:x-nmos:' will never include a further ':' after the first occurrence of a '.'.
+
+For example, the URN 'urn:x-nmos:transport:rtp' above has two subclassifications of 'ucast' and 'mcast'.
+
+API clients interpreting URNs MUST correctly recognise any as-yet undefined subclassifications as being associated with the URN root which appears prior to the first '.' character.
+
+For example, if filtering by the format 'urn:x-nmos:format:video', the filter is required to include any as-yet undefined subclassifications such as 'urn:x-nmos:format:video.raw'.
+
+Query API clients MUST be tolerant to URNs which have not yet been defined, but which may be added in later API versions.


### PR DESCRIPTION
Requires backporting to v1.2 and below