### PR TITLE
query: add explicit 501 requirements for all SHOULD/MAY features

### DIFF
--- a/APIs/NodeAPI.raml
+++ b/APIs/NodeAPI.raml
@@ -66,7 +66,9 @@ documentation:
 
   - title: Receiver Subscriptions
     content: |
-      This method is deprecated, but should be supported alongside any other connection mechanisms until it is removed in v2.0. Please see the NMOS Connection API specification for the current methods for creating connections between Senders and Receivers.
+      This method is deprecated, but SHOULD be supported alongside any other connection mechanisms up to and including v1.2. From v1.3 Nodes MAY choose to return a 501 response from this endpoint as opposed to implementing it.
+
+      Please see the NMOS Connection API specification for the current methods for creating connections between Senders and Receivers.
 
       A PUT request to /receivers/{receiverId}/target will modify which Sender a Receiver is subscribed to.
 
@@ -225,6 +227,7 @@ documentation:
           200:
           403:
           404:
+          501:
       put:
         description: Request a change to a Receiver's subscription (deprecated)
         body:
@@ -241,5 +244,9 @@ documentation:
               type: ErrorSchema
           404:
             description: Returned when the requested Receiver ID does not exist
+            body:
+              type: ErrorSchema
+          501:
+            description: This feature has not been implemented due to deprecation
             body:
               type: ErrorSchema

--- a/APIs/QueryAPI.raml
+++ b/APIs/QueryAPI.raml
@@ -59,6 +59,8 @@ traits:
               description: Identifies the current value of the query parameter 'paging.until' in use, or if not specified identifies what value it would have had to return this data set. This value may be re-used as the paging.since value of a query to return the next page of results. Combining this with the X-Paging-Since header value provides the absolute time bounds of the current returned data set.
               type: string
               example: 1441716120:318744030
+        501:
+          description: The query parameters specified are not currently supported by this implementation.
   - downgrade:
       description: API resource supporting the return of data which matches an older minor API version than the request would return by default.
       queryParameters:
@@ -69,6 +71,8 @@ traits:
       responses:
         400:
           description: The requested downgrade query moves between major API versions which is not permitted.
+        501:
+          description: The query parameters specified are not currently supported by this implementation.
   - rql:
       description: This resource MAY support advanced query formats using the Resource Query Language (RQL) syntax
       queryParameters:
@@ -221,6 +225,8 @@ documentation:
         body:
           example: !include ../examples/queryapi-nodes-get-200.json
           type: Nodes
+      501:
+        description: The query parameters specified are not currently supported by this implementation.
   /{nodeId}:
     uriParameters:
       nodeId:
@@ -256,6 +262,8 @@ documentation:
         body:
           example: !include ../examples/queryapi-sources-get-200.json
           type: Sources
+      501:
+        description: The query parameters specified are not currently supported by this implementation.
   /{sourceId}:
     uriParameters:
       sourceId:
@@ -291,6 +299,8 @@ documentation:
         body:
           example: !include ../examples/queryapi-flows-get-200.json
           type: Flows
+      501:
+        description: The query parameters specified are not currently supported by this implementation.
   /{flowId}:
     uriParameters:
       flowId:
@@ -326,6 +336,8 @@ documentation:
         body:
           example: !include ../examples/queryapi-devices-get-200.json
           type: Devices
+      501:
+        description: The query parameters specified are not currently supported by this implementation.
   /{deviceId}:
     uriParameters:
       deviceId:
@@ -361,6 +373,8 @@ documentation:
         body:
           example: !include ../examples/queryapi-senders-get-200.json
           type: Senders
+      501:
+        description: The query parameters specified are not currently supported by this implementation.
   /{senderId}:
     uriParameters:
       senderId:
@@ -396,6 +410,8 @@ documentation:
         body:
           example: !include ../examples/queryapi-receivers-get-200.json
           type: Receivers
+      501:
+        description: The query parameters specified are not currently supported by this implementation.
   /{receiverId}:
     uriParameters:
       receiverId:

--- a/APIs/QueryAPI.raml
+++ b/APIs/QueryAPI.raml
@@ -227,6 +227,8 @@ documentation:
           type: Nodes
       501:
         description: The query parameters specified are not currently supported by this implementation.
+        body:
+          type: ErrorSchema
   /{nodeId}:
     uriParameters:
       nodeId:
@@ -264,6 +266,8 @@ documentation:
           type: Sources
       501:
         description: The query parameters specified are not currently supported by this implementation.
+        body:
+          type: ErrorSchema
   /{sourceId}:
     uriParameters:
       sourceId:
@@ -301,6 +305,8 @@ documentation:
           type: Flows
       501:
         description: The query parameters specified are not currently supported by this implementation.
+        body:
+          type: ErrorSchema
   /{flowId}:
     uriParameters:
       flowId:
@@ -338,6 +344,8 @@ documentation:
           type: Devices
       501:
         description: The query parameters specified are not currently supported by this implementation.
+        body:
+          type: ErrorSchema
   /{deviceId}:
     uriParameters:
       deviceId:
@@ -375,6 +383,8 @@ documentation:
           type: Senders
       501:
         description: The query parameters specified are not currently supported by this implementation.
+        body:
+          type: ErrorSchema
   /{senderId}:
     uriParameters:
       senderId:
@@ -412,6 +422,8 @@ documentation:
           type: Receivers
       501:
         description: The query parameters specified are not currently supported by this implementation.
+        body:
+          type: ErrorSchema
   /{receiverId}:
     uriParameters:
       receiverId:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This document provides an overview of changes between released versions of this 
 ## Release (unreleased)
 * Under active development
 
+* Permit deprecated Node API connection management to not be implemented
+* Add explicit requirements for 501 responses when features are not implemented
 * Add support for future device and transport types
 
 ## Release v1.2

--- a/docs/2.5. APIs - Query Parameters.md
+++ b/docs/2.5. APIs - Query Parameters.md
@@ -8,7 +8,7 @@ The following document describes the expected usage and behaviour of these query
 
 ## Pagination
 
-Query APIs SHOULD support pagination of their API resources where the 'paged' trait is specified in the RAML documentation. Pagination is not used by Websocket subscriptions.
+Query APIs SHOULD support pagination of their API resources where the 'paged' trait is specified in the RAML documentation. A 501 HTTP status code MUST be returned where pagination is attempted against a Query API which does not implement it. Pagination is not used by Websocket subscriptions.
 
 The following implementation notes should be observed:
 
@@ -216,7 +216,7 @@ Payload Resources
 
 ## Downgrade Queries
 
-Query APIs SHOULD support downgrade queries against their API resources where the 'downgrade' trait is specified in the RAML documentation.
+Query APIs SHOULD support downgrade queries against their API resources where the 'downgrade' trait is specified in the RAML documentation. A 501 HTTP status code MUST be returned where a downgrade query is attempted against a Query API which does not implement it.
 
 Downgrade queries permit old-versioned responses to be provided to clients which are confident that they can handle any missing attributes between the specified API versions.
 
@@ -271,7 +271,7 @@ GET /x-nmos/query/v3.0/flows?query.downgrade=v1.0
 
 ## Basic Queries
 
-Query APIs SHOULD support basic queries against their API resources.
+Query APIs SHOULD support basic queries against their API resources. A 501 HTTP status code MUST be returned where a basic query is attempted against a Query API which does not implement it.
 
 Queries may be performed using any attribute specified in a given resource's schema, however the RAML documents only the core resource attributes for simplicity.
 
@@ -333,7 +333,7 @@ GET /x-nmos/query/v1.0/flows?tags.location=Salford&tags.location=London
 
 ## Advanced (RQL) Queries (Optional)
 
-Query APIs MAY support Resource Query Language (RQL) queries against their API resources where the 'rql' trait is specified in the RAML documentation. A 501 HTTP status code should be returned where a RAML query is attempted using RQL functions or operators which are not supported by a Query API.
+Query APIs MAY support Resource Query Language (RQL) queries against their API resources where the 'rql' trait is specified in the RAML documentation. A 501 HTTP status code MUST be returned where a RAML query is attempted using RQL functions or operators which are not supported by a Query API.
 
 ### Examples
 
@@ -359,7 +359,7 @@ GET /x-nmos/query/v1.1/sources?query.rql=and(eq(format,urn:x-nmos:format:video),
 
 ## Ancestry Queries (Optional)
 
-Query APIs MAY support Source and Flow ancestry queries against their API resources where the 'ancestry' trait is specified in the RAML documentation. A 501 HTTP status code should be returned where an ancestry query is attempted against a Query API which does not implement it.
+Query APIs MAY support Source and Flow ancestry queries against their API resources where the 'ancestry' trait is specified in the RAML documentation. A 501 HTTP status code MUST be returned where an ancestry query is attempted against a Query API which does not implement it.
 
 ### Examples
 


### PR DESCRIPTION
Includes a mechanism to reduce the overhead of Receiver subscription implementation from v1.3 onwards.