### PR TITLE
docs: indicate that clients must check for pagination headers

### DIFF
--- a/docs/2.5. APIs - Query Parameters.md
+++ b/docs/2.5. APIs - Query Parameters.md
@@ -10,6 +10,8 @@ The following document describes the expected usage and behaviour of these query
 
 Query APIs SHOULD support pagination of their API resources where the 'paged' trait is specified in the RAML documentation. A 501 HTTP status code MUST be returned where pagination is attempted against a Query API which does not implement it. Pagination is not used by Websocket subscriptions.
 
+Query API clients MUST detect whether pagination is being used by examining the HTTP response headers for 'X-Paging-Limit' which MUST be returned in all cases where pagination is in use.
+
 The following implementation notes should be observed:
 
 * The registry which backs the Query API is expected to maintain a 'creation' and 'update' timestamp alongside each registered resource. These values should not be returned to API clients in the response body, but will be made available via headers and used as pagination cursors.


### PR DESCRIPTION
Relates to part of #79. Any RAML related updates are likely to be handled as part of #84