### PR TITLE
mdns: note p2p discovery is optional from v1.3

### DIFF
--- a/APIs/NodeAPI.raml
+++ b/APIs/NodeAPI.raml
@@ -27,7 +27,7 @@ documentation:
       The Node API is exposed by each NMOS Node in a system, regardless of whether it is possible for that Node to provide NMOS resources such as Flows, Sources etc. Data exposed by the Node API is used to populate the (distributed) registry via the Registration API. In smaller deployments the Node API is fetched from directly as required by Nodes which implement the Peer to Peer specification.
   - title: DNS-SD Advertisement
     content: |
-      Node APIs MUST produce an mDNS advertisement of the type \_nmos-node.\_tcp. This MAY be accompanied by a unicast DNS announcement of the same type.
+      Node APIs MUST produce an mDNS advertisement of the type \_nmos-node.\_tcp. This MAY be accompanied by a unicast DNS announcement of the same type. Note that peer to peer mode and Node mDNS announcements are optional from v1.3 of the specification.
 
       The IP address and port of the Node API MUST be identified via the DNS-SD advertisement, with the full HTTP path then being resolved via the standard NMOS API path documentation.
 

--- a/docs/3.2. Discovery - Peer to Peer Operation.md
+++ b/docs/3.2. Discovery - Peer to Peer Operation.md
@@ -2,7 +2,7 @@
 
 _(c) AMWA 2016, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
 
-This document describes usage of NMOS APIs for discovery in cases where where a distributed registry is not available, such as small ad-hoc installations.
+This document describes usage of NMOS APIs for discovery in cases where where a distributed registry is not available, such as small ad-hoc installations. This feature is optional from v1.3 of the specification.
 
 Note that the peer to peer discovery mechanism depends upon mDNS which is not intended to operate over IP routed boundaries (ie. between network subnets). As such it is recommended that for most use cases, in particular fixed installations and those requiring high levels of resilience, the registered discovery mechanism is used.
 


### PR DESCRIPTION
Resolves #94 

This note will be added to the v1.2.x branch and earlier.