### PR TITLE
Permit a Sender's 'manifest_href' to be null

### DIFF
--- a/APIs/schemas/sender.json
+++ b/APIs/schemas/sender.json
@@ -49,8 +49,8 @@
           "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "manifest_href": {
-          "description": "HTTP URL to a file describing how to connect to the Sender (SDP for RTP). The Sender's 'version' attribute should be updated if the contents of this file are modified. This URL may return an HTTP 404 where the 'active' parameter in the 'subscription' object is present and set to false (v1.2+ only).",
-          "type": "string",
+          "description": "HTTP URL to a file describing how to connect to the Sender (SDP for RTP). The Sender's 'version' attribute should be updated if the contents of this file are modified. This URL may return an HTTP 404 where the 'active' parameter in the 'subscription' object is present and set to false (v1.2+ only). The value should be null when the transport type used by the Sender does not require a transport file.",
+          "type": ["string", "null"],
           "format": "uri"
         },
         "interface_bindings": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This document provides an overview of changes between released versions of this 
 * Permit deprecated Node API connection management to not be implemented
 * Add explicit requirements for 501 responses when features are not implemented
 * Add support for future device and transport types
+* Permit a Sender's 'manifest_href' to be null when the transport type does not require a transport file
 
 ## Release v1.2
 * Add network interfaces and bindings to Nodes, Senders and Receivers

--- a/docs/6.0. Upgrade Path.md
+++ b/docs/6.0. Upgrade Path.md
@@ -57,6 +57,7 @@ It is strongly recommended to match Query API client compatibility to the maximu
 
 *   Devices: 'type' may be listed as any new variant of 'urn:x-nmos:device'
 *   Senders: 'transport' may be listed as any new variant of 'urn:x-nmos:transport'
+*   Senders: 'manifest_href' may be listed as `null` for transport types that do not require a transport file
 *   Receivers: 'transport' may be listed as any new variant of 'urn:x-nmos:transport'
 
 ### Affected Keys From v1.2
@@ -67,7 +68,7 @@ No keys are affected
 
 *   Sources: 'format' may be listed as 'urn:x-nmos:format:mux'
 *   Flows: 'format' may be listed as 'urn:x-nmos:format:mux'
-*   Senders: 'flow_id' may be listed as 'null'
+*   Senders: 'flow_id' may be listed as `null`
 
 ## Performing Upgrades
 


### PR DESCRIPTION
…when the transport type does not require a transport file.

Partially resolves https://github.com/AMWA-TV/nmos-event-tally/issues/38.
Related to https://github.com/AMWA-TV/nmos-device-connection-management/pull/72.