### PR TITLE
docs: clarify client expectations around trailing slashes

### DIFF
--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -88,6 +88,10 @@ In order to overcome shortcomings in some common libraries, the following requir
 * Servers implementing the APIs MAY correctly interpret requests using these methods to paths with trailing slashes present for backward compatibility.
 * Servers SHOULD NOT respond with 3xx codes for these request types.
 
+#### Client Behaviour
+
+When a server implementation is required to indicate an API URL via an 'href' or similar attribute, it is valid to either include a trailing slash or not provided that the listed path is accessible and abides by the policy above. In order to avoid cases of double slashes or missing slashes, clients are required to exercise caution when appending paths onto 'href' type attributes.
+
 ### Error Codes & Responses
 
 The NMOS APIs use HTTP status codes to indicate success, failure and other cases to clients as per [RFC 7231](https://tools.ietf.org/html/rfc7231) and related standards. Where the RAML specification of an API specifies explicit response codes it is expected that a client will handle these cases in a particular way. As explicit handling of every possible HTTP response code is not expected, clients must instead implement more generic handling for ranges of response codes (1xx, 2xx, 3xx, 4xx and 5xx). For HTTP codes 400 and upwards, a JSON format response MUST be returned as follows:


### PR DESCRIPTION
Relates to #87 

This advice would be best carried in NMOS Core when it is developed in order to reduce duplication in other specifications.