### PR TITLE
schemas: permit future values for transfer_characteristic/colorspace

### DIFF
--- a/APIs/schemas/flow_video.json
+++ b/APIs/schemas/flow_video.json
@@ -42,23 +42,37 @@
           ]
         },
         "colorspace" : {
-          "description" : "Colorspace used for the video",
+          "description" : "Colorspace used for the video. Any values not defined in the enum should be defined in the parameter registers",
           "type" : "string",
-          "enum" : [
-            "BT601",
-            "BT709",
-            "BT2020",
-            "BT2100"
+          "anyOf": [
+            {
+              "enum": [
+                "BT601",
+                "BT709",
+                "BT2020",
+                "BT2100"
+              ]
+            },
+            {
+              "pattern": "^\\S+$"
+            }
           ]
         },
         "transfer_characteristic": {
-          "description": "Transfer characteristic",
+          "description": "Transfer characteristic. Any values not defined in the enum should be defined in the parameter registers",
           "type": "string",
           "default": "SDR",
-          "enum": [
-            "SDR",
-            "HLG",
-            "PQ"
+          "anyOf": [
+            {
+              "enum": [
+                "SDR",
+                "HLG",
+                "PQ"
+              ]
+            },
+            {
+              "pattern": "^\\S+$"
+            }
           ]
         }
       }

--- a/APIs/schemas/flow_video.json
+++ b/APIs/schemas/flow_video.json
@@ -42,7 +42,7 @@
           ]
         },
         "colorspace" : {
-          "description" : "Colorspace used for the video. Any values not defined in the enum should be defined in the parameter registers",
+          "description" : "Colorspace used for the video. Any values not defined in the enum should be defined in the NMOS Parameter Registers",
           "type" : "string",
           "anyOf": [
             {
@@ -59,7 +59,7 @@
           ]
         },
         "transfer_characteristic": {
-          "description": "Transfer characteristic. Any values not defined in the enum should be defined in the parameter registers",
+          "description": "Transfer characteristic. Any values not defined in the enum should be defined in the NMOS Parameter Registers",
           "type": "string",
           "default": "SDR",
           "anyOf": [

--- a/docs/6.0. Upgrade Path.md
+++ b/docs/6.0. Upgrade Path.md
@@ -58,6 +58,8 @@ It is strongly recommended to match Query API client compatibility to the maximu
 ### Affected Keys From v1.3
 
 *   Devices: 'type' may be listed as any new variant of 'urn:x-nmos:device'
+*   Flows: 'transfer_characteristic' may be listed as any string to permit future extensibility
+*   Flows: 'colorspace' may be listed as any string to permit future extensibility
 *   Senders: 'transport' may be listed as any new variant of 'urn:x-nmos:transport'
 *   Senders: 'manifest_href' may be listed as `null` for transport types that do not require a transport file
 *   Receivers: 'transport' may be listed as any new variant of 'urn:x-nmos:transport'


### PR DESCRIPTION
This is a proposal to resolve https://github.com/AMWA-TV/nmos-discovery-registration/issues/23

In order to avoid excessive version bumps in the future we may wish to make use of the parameter registers to keep track of additional attributes which are defined, in particular for Sources and Flows. Use of enums makes this hard. Having looked at where enums are currently used I think these video Flow cases are the worst offenders and could be modified to allow for the current defined values, but accept any future values which may be defined externally.