### PR TITLE
docs: add clarifications for ws 'secure' and TX/RX 'subscription'

### DIFF
--- a/APIs/QueryAPI.raml
+++ b/APIs/QueryAPI.raml
@@ -183,13 +183,13 @@ documentation:
 
       Not all RQL operators will be suitable for use with a Query API. It is suggested that the following operators are supported, however these are not mandated and implementations may choose to support their own subset.
 
-      1) Functions: in(), out(), sort(), like(), select()
+      1) Functions: in(), out(), select()
 
       2) Logical Operators: and(), or(), not()
 
       3) Relational Operators: eq(), ne(), gt(), ge(), lt(), le()
 
-      NB: It is suggested that limit() is not implemented as paging and associated limits is specified directly by the Query API.
+      NB: It is suggested that sort() and limit() are not implemented as paging and associated limits is specified directly by the Query API.
 
       ** Querying Ancestry **
 

--- a/docs/4.2. Behaviour - Querying.md
+++ b/docs/4.2. Behaviour - Querying.md
@@ -4,6 +4,14 @@ _(c) AMWA 2016, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
 
 The Query API provides a read-only interface to the Nodes and their sub-resources which are currently held in the registry. Browsing of the Query API may be performed via the RESTful API, or by using the websocket protocol ([RFC 6455](https://tools.ietf.org/html/rfc6455)) which is suggested for most applications.
 
+## API Resources
+
+Where the behaviour associated with an API attribute is not sufficiently clear from its name and schema constraints, this is documented below.
+
+### Subscriptions
+
+`secure` Indicates whether the WebSocket connection is provided via an encrypted connection or not (ws:// vs. wss://). Unless otherwise indicated the value of this attribute SHOULD be 'false' if the API is being presented via HTTP, and 'true' for HTTPS. Query API clients MAY choose to specify the opposite value in requests for subscriptions, however they will receive a 400 response code unless the Query API explicitly supports a mismatch between encrypted HTTP and WebSocket connections.
+
 ## Creating a Websocket subscription
 
 In order to connect to a websocket, a client must first request a subscription of a particular type and with particular query parameters by performing a POST as defined in the [Query API](../APIs/QueryAPI.raml) subscriptions documentation. Use of GET requests to find existing suitable websocket connections is strongly discouraged.
@@ -15,6 +23,8 @@ Websockets created for specific clients will be cleaned up automatically if they
 Connection upgrade procedures permitting an existing HTTP query to transition to a websocket are not currently supported, but may be in the future.
 
 ### Query API Behaviour
+
+Long-lived connections to the Query API are supported via Websockets which can be set up via the /subscriptions resource. Query APIs may additionally support the HTTP 'Upgrade' header sent by clients to upgrade an HTTP GET request to a Websocket. In cases where this is performed, a corresponding entry in /subscriptions must also be created with matching query parameters.
 
 Upon receiving a request for a new subscription, the Query API should identify whether it already has any websockets open which provide for the requested query. If a websocket exists, the 'subscription' object representing it may be returned to the user. If a relevant websocket does not exist a new one should be created.
 

--- a/docs/4.3. Behaviour - Nodes.md
+++ b/docs/4.3. Behaviour - Nodes.md
@@ -1,0 +1,23 @@
+# Behaviour: Nodes
+
+_(c) AMWA 2016, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
+
+## API Resources
+
+Where the behaviour associated with an API attribute is not sufficiently clear from its name and schema constraints, this is documented below.
+
+### Senders
+
+`subscription`: The 'subscription' key is used to indicate how a Sender currently connects to Receivers in a networked media system. The subscription MUST be updated to reflect the current state of the Sender whether it was modified via an NMOS mechanism or an externally-defined control mechanism.
+
+`subscription` `active`: The 'active' key MUST be set to 'true' when the Sender is configured to enable transmission of packets to the network, whether via a push- or pull-based mechanism. The key MUST be set to 'false' when the Sender is configured to disable transmission of packets to the network.
+
+`subscription` `receiver_id`: The 'receiver_id' key MUST be set to `null` in all cases except where a unicast push-based Sender is configured to transmit to an NMOS Receiver, and the 'active' key is set to 'true'. When not set to `null`, the 'receiver_id' MUST be set to the UUID of an NMOS Receiver.
+
+### Receivers
+
+`subscription`: The 'subscription' key is used to indicate how a Receiver currently connects to Senders in a networked media system. The subscription MUST be updated to reflect the current state of the Receiver whether it was modified via an NMOS mechanism or an externally-defined control mechanism.
+
+`subscription` `active`: The 'active' key MUST be set to 'true' when the Receiver is configured to enable reception of packets from the network. The key MUST be set to 'false' when the Receiver is configured to disable reception of packets from the network.
+
+`subscription` `sender_id`: The 'sender_id' key MUST be set to `null` in all cases except where the Receiver is currently configured to receive from an NMOS Sender, and the 'active' key is set to 'true'. When not set to `null`, the 'sender_id' MUST be set to the UUID of an NMOS Sender.


### PR DESCRIPTION
Backports which resolve #76 and #80 