### PR TITLE
Add signalling for authorization requirements relating to BCP-003-02

### DIFF
--- a/APIs/schemas/device.json
+++ b/APIs/schemas/device.json
@@ -67,6 +67,11 @@
                 "type": "string",
                 "description": "URN identifying the control format",
                 "format": "uri"
+              },
+              "authorization": {
+                "type": "boolean",
+                "description": "This endpoint requires authorization",
+                "default": false
               }
             }
           }

--- a/APIs/schemas/node.json
+++ b/APIs/schemas/node.json
@@ -65,6 +65,11 @@
                     "type": "string",
                     "description": "Protocol supported by this instance of the Node API",
                     "enum": ["http", "https"]
+                  },
+                  "authorization": {
+                    "type": "boolean",
+                    "description": "This endpoint requires authorization",
+                    "default": false
                   }
                 }
               }
@@ -91,6 +96,11 @@
                 "type": "string",
                 "description": "URN identifying the type of service",
                 "format": "uri"
+              },
+              "authorization": {
+                "type": "boolean",
+                "description": "This endpoint requires authorization",
+                "default": false
               }
             }
           }

--- a/APIs/schemas/queryapi-subscription-response.json
+++ b/APIs/schemas/queryapi-subscription-response.json
@@ -45,6 +45,11 @@
     "params": {
       "description": "Object containing attributes to filter the resource on as per the Query Parameters specification. Can be empty.",
       "type": "object"
+    },
+    "authorization": {
+      "type": "boolean",
+      "description": "This WebSocket requires authorization",
+      "default": false
     }
   }
 }

--- a/APIs/schemas/queryapi-subscriptions-post-request.json
+++ b/APIs/schemas/queryapi-subscriptions-post-request.json
@@ -32,6 +32,10 @@
     "params": {
       "description": "Object containing attributes to filter the resource on as per the Query Parameters specification. Can be empty.",
       "type": "object"
+    },
+    "authorization": {
+      "type": "boolean",
+      "description": "This WebSocket requires authorization"
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This document provides an overview of changes between released versions of this 
 * Add explicit requirements for 501 responses when features are not implemented
 * Add support for future device and transport types
 * Permit a Sender's 'manifest_href' to be null when the transport type does not require a transport file
+* Add support for signalling authorization requirements
 
 ## Release v1.2
 * Add network interfaces and bindings to Nodes, Senders and Receivers

--- a/docs/3.1. Discovery - Registered Operation.md
+++ b/docs/3.1. Discovery - Registered Operation.md
@@ -27,6 +27,10 @@ The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_proto
 
 The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_ver'. The value of this TXT record is a comma separated list of API versions supported by the server. For example: 'v1.0,v1.1,v2.0'. There should be no whitespace between commas, and versions should be listed in ascending order.
 
+**api\_auth**
+
+The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_auth' with a value of either 'true' or 'false' dependent on whether authorization is required in order to interact with the Registration API or not.
+
 **pri**
 
 The DNS-SD advertisement MUST include a TXT record with key 'pri' and an integer value. Servers MAY additionally represent a matching priority via the DNS-SD SRV record 'priority' and 'weight' as defined in RFC 2782. The TXT record should be used in favour to the SRV priority and weight where these values differ in order to overcome issues in the Bonjour and Avahi implementations.
@@ -65,6 +69,10 @@ The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_proto
 **api\_ver**
 
 The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_ver'. The value of this TXT record is a comma separated list of API versions supported by the server. For example: 'v1.0,v1.1,v2.0'. There should be no whitespace between commas, and versions should be listed in ascending order.
+
+**api\_auth**
+
+The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_auth' with a value of either 'true' or 'false' dependent on whether authorization is required in order to interact with the Query API or not.
 
 **pri**
 

--- a/docs/3.1. Discovery - Registered Operation.md
+++ b/docs/3.1. Discovery - Registered Operation.md
@@ -41,7 +41,7 @@ Values 0 to 99 correspond to an active NMOS Registration API (zero being the hig
 1. Node comes online
 2. Node scans for an active Registration API on the network using unicast and/or multicast DNS service discovery (type '\_nmos-register.\_tcp')
    *  Nodes which support v1.2 and earlier versions MUST additionally browse for the deprecated service type '\_nmos-registration.\_tcp'.
-3. Given multiple returned Registration APIs, the Node orders these based on their advertised priority (TXT pri), filtering out any APIs which do not support its required API version and protocol (TXT api_ver and api_proto).
+3. Given multiple returned Registration APIs, the Node orders these based on their advertised priority (TXT pri), filtering out any APIs which do not support its required API version, protocol and authorization mode (TXT api_ver, api_proto and api_auth).
    *  Where a Node supports multiple API versions simultaneously, see the [Upgrade Path](6.0.%20Upgrade%20Path.md) for additional requirements in filtering the discovered API list.
 4. The Node selects a Registration API to use based on the priority, and a random selection if multiple Registration APIs of the same API version with the same priority are identified.
 5. Node proceeds to register its resources with the selected Registration API.
@@ -83,7 +83,7 @@ Values 0 to 99 correspond to an active NMOS Query API (zero being the highest pr
 
 1. Node (or control interface) comes online
 2. Node scans for an active Query API on the network using unicast and/or multicast DNS service discovery (type '\_nmos-query.\_tcp')
-3. Given multiple returned Query APIs, the Node orders these based on their advertised priority (TXT pri), filtering out any APIs which do not support its required API version and protocol (TXT api_ver and api_proto).
+3. Given multiple returned Query APIs, the Node orders these based on their advertised priority (TXT pri), filtering out any APIs which do not support its required API version, protocol and authorization mode (TXT api_ver, api_proto and api_auth).
    *  Where a Node supports multiple API versions simultaneously, see the [Upgrade Path](6.0.%20Upgrade%20Path.md) for additional requirements in filtering the discovered API list.
 4. The Node selects a Query API to use based on the priority, and a random selection if multiple Query APIs of the same version with the same priority are identified.
 5. Node proceeds to request data as required from the selected Query API.

--- a/docs/3.2. Discovery - Peer to Peer Operation.md
+++ b/docs/3.2. Discovery - Peer to Peer Operation.md
@@ -33,6 +33,10 @@ The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_proto
 
 The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_ver'. The value of this TXT record is a comma separated list of API versions supported by the server. For example: 'v1.0,v1.1,v2.0'. There should be no whitespace between commas, and versions should be listed in ascending order.
 
+**api\_auth**
+
+The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_auth' with a value of either 'true' or 'false' dependent on whether authorization is required in order to interact with the Node API or not.
+
 **ver\_**
 
 When a Node is operating in peer-to-peer mode it MUST additionally advertise the following mDNS TXT records as part of its Node advertisement. If a Node is successfully registered with a Registration API it MUST withdraw advertisements of these TXT records. There is no requirement to register these TXT records with a unicast DNS service.

--- a/docs/4.2. Behaviour - Querying.md
+++ b/docs/4.2. Behaviour - Querying.md
@@ -12,6 +12,8 @@ Where the behaviour associated with an API attribute is not sufficiently clear f
 
 `secure` Indicates whether the WebSocket connection is provided via an encrypted connection or not (ws:// vs. wss://). Unless otherwise indicated the value of this attribute SHOULD be 'false' if the API is being presented via HTTP, and 'true' for HTTPS. Query API clients MAY choose to specify the opposite value in requests for subscriptions, however they will receive a 400 response code unless the Query API explicitly supports a mismatch between encrypted HTTP and WebSocket connections.
 
+`authorization` Indicates whether the WebSocket connection requires authorization in order to connect or not. Use of authorization is likely to be a deployment decision and be the same for all subscriptions exposed from a single Query API. Query API clients MAY choose to specify a requested value for this attribute, but in most circumstances this will result in a 400 response code if the Query API is operating in the opposite mode.
+
 ## Creating a Websocket subscription
 
 In order to connect to a websocket, a client must first request a subscription of a particular type and with particular query parameters by performing a POST as defined in the [Query API](../APIs/QueryAPI.raml) subscriptions documentation. Use of GET requests to find existing suitable websocket connections is strongly discouraged.

--- a/docs/4.2. Behaviour - Querying.md
+++ b/docs/4.2. Behaviour - Querying.md
@@ -12,7 +12,7 @@ Where the behaviour associated with an API attribute is not sufficiently clear f
 
 `secure` Indicates whether the WebSocket connection is provided via an encrypted connection or not (ws:// vs. wss://). Unless otherwise indicated the value of this attribute SHOULD be 'false' if the API is being presented via HTTP, and 'true' for HTTPS. Query API clients MAY choose to specify the opposite value in requests for subscriptions, however they will receive a 400 response code unless the Query API explicitly supports a mismatch between encrypted HTTP and WebSocket connections.
 
-`authorization` Indicates whether the WebSocket connection requires authorization in order to connect or not. Use of authorization is likely to be a deployment decision and be the same for all subscriptions exposed from a single Query API. Query API clients MAY choose to specify a requested value for this attribute, but in most circumstances this will result in a 400 response code if the Query API is operating in the opposite mode.
+`authorization` Indicates whether the WebSocket connection requires authorization in order to connect or not. Use of authorization is likely to be a deployment decision and be the same for all subscriptions exposed from a single Query API, and for the RESTful API itself. Query API clients MAY choose to specify a requested value for this attribute, but in most circumstances this will result in a 400 response code if the Query API is operating in the opposite mode.
 
 ## Creating a Websocket subscription
 

--- a/docs/6.0. Upgrade Path.md
+++ b/docs/6.0. Upgrade Path.md
@@ -32,7 +32,8 @@ Nodes which support multiple versions simultaneously MUST ensure that all of the
 
 ### v1.3 to v1.2
 
-No keys require removal
+*   Nodes: 'authorization' (in 'api' 'endpoints'), 'authorization' (in 'services')
+*   Devices: 'authorization' (in 'controls')
 
 ### v1.2 to v1.1
 


### PR DESCRIPTION
Resolves #101 

I've intentionally made none of these attributes 'required' and set the default to 'false'. Where authorization is enabled they will need to be present and set to 'true'.

I'm not sure it's really necessary to permit inclusion of the attribute in Query API WebSocket requests, but I have done in case there is a genuine use case where this is useful. The notes reflect the general case where Query APIs will be operating in one mode only.