### PR TITLE
docs: re-order upgrade advice to avoid issues with pre-upgraded Nodes

### DIFF
--- a/docs/6.0. Upgrade Path.md
+++ b/docs/6.0. Upgrade Path.md
@@ -76,10 +76,10 @@ No keys are affected
 
 ## Performing Upgrades
 
-The following procedure is suggested for a live system which needs to migrate between API versions:
+The following procedure is suggested for a live system which needs to migrate between API versions. This guide assumes that the registry and key clients support the Query API downgrade feature.
 
 * Upgrade the Query API(s) to support serving the new version of responses, whilst providing backwards compatibility to old versions active in the running system.
-* Upgrade Query API clients which support the ?query.downgrade parameter and as such can still access all data in the system.
+* Upgrade Query API clients which support the ?query.downgrade parameter and as such can still access all data in the system. Check ahead of doing this that the Query API server implementation supports the downgrade feature.
 * Upgrade the registry and Registration API(s) to support registrations using the new version, whilst continuing to support registrations at the old version.
 * Upgrade Nodes in the system to register against the new API version. Any Nodes which also interact with the Query API should continue to query using the old version initially unless they support downgrade queries.
 * Once all relevant Nodes have been upgraded, all Query API clients may be upgraded or instructed to perform queries against the new version.

--- a/docs/6.0. Upgrade Path.md
+++ b/docs/6.0. Upgrade Path.md
@@ -79,7 +79,7 @@ No keys are affected
 The following procedure is suggested for a live system which needs to migrate between API versions:
 
 * Upgrade the Query API(s) to support serving the new version of responses, whilst providing backwards compatibility to old versions active in the running system.
-* Upgrade the registry and Registration API(s) to support registrations using the new version, whilst continuing to support registrations at the old version.
 * Upgrade Query API clients which support the ?query.downgrade parameter and as such can still access all data in the system.
+* Upgrade the registry and Registration API(s) to support registrations using the new version, whilst continuing to support registrations at the old version.
 * Upgrade Nodes in the system to register against the new API version. Any Nodes which also interact with the Query API should continue to query using the old version initially unless they support downgrade queries.
 * Once all relevant Nodes have been upgraded, all Query API clients may be upgraded or instructed to perform queries against the new version.


### PR DESCRIPTION
There is a chance that if a Node in the system already supports v1.3 ahead of a system upgrade from v1.2 it may start registering at v1.3 once the new Registration APIs become available. If the downgrade supporting clients are upgraded first this should be less of an issue as these Nodes will always remain visible.