### PR TITLE
docs: add a note regarding caps, sources and flows and potential future uses

### DIFF
--- a/docs/4.3. Behaviour - Nodes.md
+++ b/docs/4.3. Behaviour - Nodes.md
@@ -6,6 +6,10 @@ _(c) AMWA 2016, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
 
 Where the behaviour associated with an API attribute is not sufficiently clear from its name and schema constraints, this is documented below.
 
+### All Resources
+
+`caps`: Capabilities are intended to signal a collection of inputs or outputs which a given resource is able to consume or produce, but which it may not be doing at this instant. For example, Receiver capabilities indicate the types of data a Receiver may consume from a network. The specification defines capabilities of 'media\_types' and 'event\_types' for Receivers which take an array form. Future additions to capabilities and the structure which they use may be documented external to this specification.
+
 ### Senders
 
 `subscription`: The 'subscription' key is used to indicate how a Sender currently connects to Receivers in a networked media system. The subscription MUST be updated to reflect the current state of the Sender whether it was modified via an NMOS mechanism or an externally-defined control mechanism.

--- a/docs/4.3. Behaviour - Nodes.md
+++ b/docs/4.3. Behaviour - Nodes.md
@@ -10,6 +10,10 @@ Where the behaviour associated with an API attribute is not sufficiently clear f
 
 `caps`: Capabilities are intended to signal a collection of inputs or outputs which a given resource is able to consume or produce, but which it may not be doing at this instant. For example, Receiver capabilities indicate the types of data a Receiver may consume from a network. The specification defines capabilities of 'media\_types' and 'event\_types' for Receivers which take an array form. Future additions to capabilities and the structure which they use may be documented external to this specification.
 
+### Sources & Flows
+
+Core Source and Flow attributes are defined directly within this specification. Future additions to Source and Flow attributes or expansions of permitted values for existing attributes may be documented external to this specification.
+
 ### Senders
 
 `subscription`: The 'subscription' key is used to indicate how a Sender currently connects to Receivers in a networked media system. The subscription MUST be updated to reflect the current state of the Sender whether it was modified via an NMOS mechanism or an externally-defined control mechanism.

--- a/docs/6.0. Upgrade Path.md
+++ b/docs/6.0. Upgrade Path.md
@@ -53,7 +53,7 @@ Nodes which support multiple versions simultaneously MUST ensure that all of the
 
 Implementers of Query API clients MUST support at least one API version. Query API clients are strongly recommended to make use of the query downgrade mechanism in order to provide access to the widest possible range of Nodes' resources.
 
-Implementers should be aware that when operating a client against a Query API version lower than the maximum supported version by that Query API instance, they may be exposed to resource data beyond the scope of that API version's associated schemas. Whilst the [Version Translation](#version-translations) mechanism should remove access to invalid additional keys, new values for existing keys are not excluded by this mechanism and should be handled gracefully.
+Implementers should be aware that when operating a client against a Query API version lower than the maximum supported version by that Query API instance, they may be exposed to resource data beyond the scope of that API version's associated schemas. Clients SHOULD NOT attempt to access attributes which were only defined in a later specification version. Whilst the [Version Translation](#version-translations) mechanism should remove access to invalid additional keys, new values for existing keys are not excluded by this mechanism and should be handled gracefully.
 
 It is strongly recommended to match Query API client compatibility to the maximum API version supported by a given Query API instance prior to introducing any Nodes supporting that API version to an existing system. Parameters which are known to introduce this issue are noted below:
 

--- a/docs/6.0. Upgrade Path.md
+++ b/docs/6.0. Upgrade Path.md
@@ -24,7 +24,7 @@ Query APIs are not required to provide for forwards compatibility as it may be i
 
 ### Version Translations
 
-When conforming a resource to an earlier API version, the following keys MUST be removed. These are documented here for clarity, but the same data could be derived from analysis of the schema changes between API versions.
+When conforming a resource to an earlier API version, Query API implementations SHOULD make best efforts to remove attributes which were not references in earlier versions' schemas. The core attributes which fall into this category are documented here for clarity, but the same data could be derived from analysis of the schema changes between API versions. Note that new attributes may defined external to this specification in the future. Implementations should consider this when considering how to implement this requirement.
 
 Note that removal of these keys does not guarantee conformance to the schema of the earlier API version due to the addition of new 'enum' values and similar features in more recent API versions. As such, Query APIs SHOULD NOT validate translated resources against schemas.
 
@@ -53,7 +53,7 @@ Nodes which support multiple versions simultaneously MUST ensure that all of the
 
 Implementers of Query API clients MUST support at least one API version. Query API clients are strongly recommended to make use of the query downgrade mechanism in order to provide access to the widest possible range of Nodes' resources.
 
-Implementers should be aware that when operating a client against a Query API version lower than the maximum supported version by that Query API instance, they may be exposed to resource data beyond the scope of that API version's associated schemas. Whilst the [Version Translation](#version-translations) mechanism will remove access to invalid additional keys, new values for existing keys are not excluded by this mechanism.
+Implementers should be aware that when operating a client against a Query API version lower than the maximum supported version by that Query API instance, they may be exposed to resource data beyond the scope of that API version's associated schemas. Whilst the [Version Translation](#version-translations) mechanism should remove access to invalid additional keys, new values for existing keys are not excluded by this mechanism and should be handled gracefully.
 
 It is strongly recommended to match Query API client compatibility to the maximum API version supported by a given Query API instance prior to introducing any Nodes supporting that API version to an existing system. Parameters which are known to introduce this issue are noted below:
 


### PR DESCRIPTION
This is intended to resolve #89 as far as v1.3 goes. It doesn't make any changes, but notes explicitly that additional 'caps' may be defined externally in the future in order to avoid unnecessary version bumps.

'caps' have been omitted from the version translations documentation up to now, so wouldn't necessarily need explicit handling in relation to visibility across the boundaries of API versions.