### PR TITLE
docs: prevent mDNS browsing when unicast records are available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This document provides an overview of changes between released versions of this 
 * Add 409 response code for registries with conflicting resources
 * Add support for signalling authorization requirements
 * Indicate potential for Source/Flow attributes and 'caps' to be defined externally in the future
+* Revise discovery process to ignore mDNS records when unicast records are available
 
 ## Release v1.2
 * Add network interfaces and bindings to Nodes, Senders and Receivers

--- a/docs/3.0. Discovery.md
+++ b/docs/3.0. Discovery.md
@@ -23,9 +23,10 @@ Dependent on the architecture of a network, it may make sense to use one or both
 When performing a DNS-SD browse, clients should proceed as follows:
 
 1. Identify whether the client has been configured with DNS server addresses and a default search domain either manually or automatically via DHCP.
-2. If such configuration exists, perform a unicast DNS browse for services of type '\_nmos-register.\_tcp' via the search domain.
-3. Perform a multicast DNS browse for services of type '\_nmos-register.\_tcp' in the '.local' domain unless explicitly configured not to do so.
-4. Merge the results of the two operations into a list, sorted using the priority values associated with each record, and discarding any advertisements which do not meet the Node's requirements.
+2. If such configuration exists and the discovery mechanism is not explicitly set to mDNS, perform a unicast DNS browse for services of the required type via the search domain.
+3. If no unicast responses are received and the discovery mechanism is not explicitly set to unicast DNS, perform a multicast DNS browse for services of the required type in the '.local' domain.
+   * Note that if a unicast response is received, multicast browsing should not be performed even if the unicast-discovered API is unresponsive.
+4. Merge the results of the above operations into a list, sorted using the priority values associated with each record, and discarding any advertisements which do not meet the Node's requirements.
 5. The above list should be maintained via the methods defined by the DNS-SD specification.
 
 ## Implementation Notes

--- a/docs/3.0. Discovery.md
+++ b/docs/3.0. Discovery.md
@@ -26,8 +26,9 @@ When performing a DNS-SD browse, clients should proceed as follows:
 2. If such configuration exists and the discovery mechanism is not explicitly set to mDNS, perform a unicast DNS browse for services of the required type via the search domain.
 3. If no unicast responses are received and the discovery mechanism is not explicitly set to unicast DNS, perform a multicast DNS browse for services of the required type in the '.local' domain.
    * Note that if a unicast response is received, multicast browsing should not be performed even if the unicast-discovered API is unresponsive.
-4. Merge the results of the above operations into a list, sorted using the priority values associated with each record, and discarding any advertisements which do not meet the Node's requirements.
-5. The above list should be maintained via the methods defined by the DNS-SD specification.
+4. Where both unicast and multicast DNS are used, merge the results of the above operations into a single list.
+5. Sort the list of discovered services using the priority values associated with each record, and discard any advertisements which do not meet the Node's requirements.
+6. The above list should be maintained via the methods defined by the DNS-SD specification.
 
 ## Implementation Notes
 

--- a/docs/3.1. Discovery - Registered Operation.md
+++ b/docs/3.1. Discovery - Registered Operation.md
@@ -39,7 +39,7 @@ Values 0 to 99 correspond to an active NMOS Registration API (zero being the hig
 ### Client Interaction Procedure
 
 1. Node comes online
-2. Node scans for an active Registration API on the network using unicast and/or multicast DNS service discovery (type '\_nmos-register.\_tcp')
+2. Node scans for an active Registration API on the network using unicast and/or multicast DNS service discovery (type '\_nmos-register.\_tcp') as described in the [Discovery](3.0.%20Discovery.md#unicast-vs-multicast-dns-sd) document.
    *  Nodes which support v1.2 and earlier versions MUST additionally browse for the deprecated service type '\_nmos-registration.\_tcp'.
 3. Given multiple returned Registration APIs, the Node orders these based on their advertised priority (TXT pri), filtering out any APIs which do not support its required API version, protocol and authorization mode (TXT api_ver, api_proto and api_auth).
    *  Where a Node supports multiple API versions simultaneously, see the [Upgrade Path](6.0.%20Upgrade%20Path.md) for additional requirements in filtering the discovered API list.
@@ -82,7 +82,7 @@ Values 0 to 99 correspond to an active NMOS Query API (zero being the highest pr
 ### Client Interaction Procedure
 
 1. Node (or control interface) comes online
-2. Node scans for an active Query API on the network using unicast and/or multicast DNS service discovery (type '\_nmos-query.\_tcp')
+2. Node scans for an active Query API on the network using unicast and/or multicast DNS service discovery (type '\_nmos-query.\_tcp') as described in the [Discovery](3.0.%20Discovery.md#unicast-vs-multicast-dns-sd) document.
 3. Given multiple returned Query APIs, the Node orders these based on their advertised priority (TXT pri), filtering out any APIs which do not support its required API version, protocol and authorization mode (TXT api_ver, api_proto and api_auth).
    *  Where a Node supports multiple API versions simultaneously, see the [Upgrade Path](6.0.%20Upgrade%20Path.md) for additional requirements in filtering the discovered API list.
 4. The Node selects a Query API to use based on the priority, and a random selection if multiple Query APIs of the same version with the same priority are identified.


### PR DESCRIPTION
This PR adjusts the discovery procedure to ensure that when unicast records are available, these are used in preference to any mDNS records which may be available on the same network. This holds true unless the Node supports a configuration parameter for the user to choose between unicast and multicast DNS.