### PR TITLE
node: add explicit 409 code for version conflicts

### DIFF
--- a/APIs/NodeAPI.raml
+++ b/APIs/NodeAPI.raml
@@ -71,6 +71,13 @@ documentation:
           description: Returned when the requested Source ID does not exist
           body:
             type: ErrorSchema
+        409:
+          description: Returned when the requested Source ID exists at a higher API version, and the resource cannot be conformed to the requested API version. The correct API version is identified via the Location header.
+          body:
+            type: ErrorSchema
+          headers:
+            Location:
+              example: /x-nmos/node/{version}/sources/4569cea2-ab63-4f97-8dd1-bad4669ea5e4
 /flows:
   displayName: Flows
   get:
@@ -96,6 +103,13 @@ documentation:
           description: Returned when the requested Flow ID does not exist
           body:
             type: ErrorSchema
+        409:
+          description: Returned when the requested Flow ID exists at a higher API version, and the resource cannot be conformed to the requested API version. The correct API version is identified via the Location header.
+          body:
+            type: ErrorSchema
+          headers:
+            Location:
+              example: /x-nmos/node/{version}/flows/5fbec3b1-1b0f-417d-9059-8b94a47197ed
 /devices:
   displayName: Devices
   get:
@@ -121,6 +135,13 @@ documentation:
           description: Returned when the requested Device ID does not exist
           body:
             type: ErrorSchema
+        409:
+          description: Returned when the requested Device ID exists at a higher API version, and the resource cannot be conformed to the requested API version. The correct API version is identified via the Location header.
+          body:
+            type: ErrorSchema
+          headers:
+            Location:
+              example: /x-nmos/node/{version}/devices/67c25159-ce25-4000-a66c-f31fff890265
 /senders:
   displayName: Senders
   get:
@@ -146,6 +167,13 @@ documentation:
           description: Returned when the requested Sender ID does not exist
           body:
             type: ErrorSchema
+        409:
+          description: Returned when the requested Sender ID exists at a higher API version, and the resource cannot be conformed to the requested API version. The correct API version is identified via the Location header.
+          body:
+            type: ErrorSchema
+          headers:
+            Location:
+              example: /x-nmos/node/{version}/senders/d7aa5a30-681d-4e72-92fb-f0ba0f6f4c3e
 /receivers:
   displayName: Receivers
   get:
@@ -171,6 +199,13 @@ documentation:
           description: Returned when the requested Receiver ID does not exist
           body:
             type: ErrorSchema
+        409:
+          description: Returned when the requested Receiver ID exists at a higher API version, and the resource cannot be conformed to the requested API version. The correct API version is identified via the Location header.
+          body:
+            type: ErrorSchema
+          headers:
+            Location:
+              example: /x-nmos/node/{version}/receivers/1eb53d65-ac83-441c-86f6-9b27df30ef0c
     /target:
       options:
         description: A pre-flight check generally used for Cross-Origin Resource Sharing (CORS) purposes
@@ -197,6 +232,13 @@ documentation:
             description: Returned when the requested Receiver ID does not exist
             body:
               type: ErrorSchema
+          409:
+            description: Returned when the requested Receiver ID exists at a higher API version, and the resource cannot be conformed to the requested API version. The correct API version is identified via the Location header.
+            body:
+              type: ErrorSchema
+            headers:
+              Location:
+                example: /x-nmos/node/{version}/receivers/1eb53d65-ac83-441c-86f6-9b27df30ef0c/target
           501:
             description: This feature has not been implemented due to deprecation
             body:

--- a/APIs/NodeAPI.raml
+++ b/APIs/NodeAPI.raml
@@ -212,8 +212,6 @@ documentation:
         responses:
           200:
           403:
-          404:
-          501:
       put:
         description: Request a change to a Receiver's subscription (deprecated)
         body:

--- a/APIs/QueryAPI.raml
+++ b/APIs/QueryAPI.raml
@@ -171,7 +171,7 @@ documentation:
             type: ErrorSchema
           headers:
             Location:
-              example: /x-nmos/query/{version}/nodes/3b8be755-08ff-452b-b217-c9151eb21193/
+              example: /x-nmos/query/{version}/nodes/3b8be755-08ff-452b-b217-c9151eb21193
 /sources:
   displayName: Sources
   get:
@@ -217,7 +217,7 @@ documentation:
             type: ErrorSchema
           headers:
             Location:
-              example: /x-nmos/query/{version}/sources/3b8be755-08ff-452b-b217-c9151eb21193/
+              example: /x-nmos/query/{version}/sources/c23c6a65-8e91-4f6c-a484-046363dbca29
 /flows:
   displayName: Flows
   get:
@@ -263,7 +263,7 @@ documentation:
             type: ErrorSchema
           headers:
             Location:
-              example: /x-nmos/query/{version}/flows/3b8be755-08ff-452b-b217-c9151eb21193/
+              example: /x-nmos/query/{version}/flows/b3bb5be7-9fe9-4324-a5bb-4c70e1084449
 /devices:
   displayName: Devices
   get:
@@ -309,7 +309,7 @@ documentation:
             type: ErrorSchema
           headers:
             Location:
-              example: /x-nmos/query/{version}/devices/3b8be755-08ff-452b-b217-c9151eb21193/
+              example: /x-nmos/query/{version}/devices/a370d258-69de-4422-860a-ee4cf32ee9f4
 /senders:
   displayName: Senders
   get:
@@ -355,7 +355,7 @@ documentation:
             type: ErrorSchema
           headers:
             Location:
-              example: /x-nmos/query/{version}/senders/3b8be755-08ff-452b-b217-c9151eb21193/
+              example: /x-nmos/query/{version}/senders/171d5c80-7fff-4c23-9383-46503eb1c63e
 /receivers:
   displayName: Receivers
   get:
@@ -401,7 +401,7 @@ documentation:
             type: ErrorSchema
           headers:
             Location:
-              example: /x-nmos/query/{version}/receivers/3b8be755-08ff-452b-b217-c9151eb21193/
+              example: /x-nmos/query/{version}/receivers/3350d113-1593-4271-a7f5-f4974415bb8e
 /subscriptions:
   displayName: Subscriptions
   options:
@@ -465,7 +465,7 @@ documentation:
             type: ErrorSchema
           headers:
             Location:
-              example: /x-nmos/query/{version}/subscriptions/3b8be755-08ff-452b-b217-c9151eb21193/
+              example: /x-nmos/query/{version}/subscriptions/7c903667-7113-4a8f-8865-1c63f9070a9e
     options:
       description: A pre-flight check generally used for Cross-Origin Resource Sharing (CORS) purposes
       responses:
@@ -491,4 +491,4 @@ documentation:
             type: ErrorSchema
           headers:
             Location:
-              example: /x-nmos/query/{version}/subscriptions/3b8be755-08ff-452b-b217-c9151eb21193/
+              example: /x-nmos/query/{version}/subscriptions/7c903667-7113-4a8f-8865-1c63f9070a9e

--- a/APIs/QueryAPI.raml
+++ b/APIs/QueryAPI.raml
@@ -471,7 +471,6 @@ documentation:
       responses:
         200:
         403:
-        404:
     delete:
       description: Delete a single subscription
       responses:

--- a/APIs/QueryAPI.raml
+++ b/APIs/QueryAPI.raml
@@ -419,10 +419,16 @@ documentation:
         body:
           example: !include ../examples/queryapi-subscriptions-post-200.json
           type: !include schemas/queryapi-subscription-response.json
+        headers:
+          Location:
+            example: /x-nmos/query/{version}/subscriptions/7c903667-7113-4a8f-8865-1c63f9070a9e
       200:
         body:
           example: !include ../examples/queryapi-subscriptions-post-200.json
           type: !include schemas/queryapi-subscription-response.json
+        headers:
+          Location:
+            example: /x-nmos/query/{version}/subscriptions/7c903667-7113-4a8f-8865-1c63f9070a9e
       400:
         description: Returned when the POST request is incorrectly formatted, missing mandatory attributes or an attribute is invalid given the API's configuration
         body:

--- a/APIs/RegistrationAPI.raml
+++ b/APIs/RegistrationAPI.raml
@@ -44,7 +44,7 @@ documentation:
           type: !include schemas/registrationapi-resource-response.json
         headers:
           Location:
-            example: /x-nmos/registration/{version}/resource/nodes/3b8be755-08ff-452b-b217-c9151eb21193/
+            example: /x-nmos/registration/{version}/resource/nodes/3b8be755-08ff-452b-b217-c9151eb21193
         description: The expected response for an update operation on an existing registered resource
       201:
         body:
@@ -52,7 +52,7 @@ documentation:
           type: !include schemas/registrationapi-resource-response.json
         headers:
           Location:
-            example: /x-nmos/registration/{version}/resource/nodes/3b8be755-08ff-452b-b217-c9151eb21193/
+            example: /x-nmos/registration/{version}/resource/nodes/3b8be755-08ff-452b-b217-c9151eb21193
         description: The expected response for a create operation performed for a previously unregistered resource
       400:
         description: Returned when the POST request is incorrectly formatted, missing mandatory attributes or breaches another condition which a Node is unlikely to be able to automatically correct.
@@ -64,7 +64,7 @@ documentation:
           type: ErrorSchema
         headers:
           Location:
-            example: /x-nmos/registration/{version}/resource/nodes/3b8be755-08ff-452b-b217-c9151eb21193/
+            example: /x-nmos/registration/{version}/resource/nodes/3b8be755-08ff-452b-b217-c9151eb21193
   /{resourceType}/{resourceId}:
     uriParameters:
       resourceId:
@@ -101,7 +101,7 @@ documentation:
             type: ErrorSchema
           headers:
             Location:
-              example: /x-nmos/registration/{version}/resource/nodes/3b8be755-08ff-452b-b217-c9151eb21193/
+              example: /x-nmos/registration/{version}/resource/nodes/3b8be755-08ff-452b-b217-c9151eb21193
     get:
       description: Show a registered resource (for debug use only)
       responses:
@@ -119,7 +119,7 @@ documentation:
             type: ErrorSchema
           headers:
             Location:
-              example: /x-nmos/registration/{version}/resource/nodes/3b8be755-08ff-452b-b217-c9151eb21193/
+              example: /x-nmos/registration/{version}/resource/nodes/3b8be755-08ff-452b-b217-c9151eb21193
 /health/nodes/{nodeId}:
   displayName: Node health
   uriParameters:
@@ -149,7 +149,7 @@ documentation:
           type: ErrorSchema
         headers:
           Location:
-            example: /x-nmos/registration/{version}/health/nodes/3b8be755-08ff-452b-b217-c9151eb21193/
+            example: /x-nmos/registration/{version}/health/nodes/3b8be755-08ff-452b-b217-c9151eb21193
   get:
     description: Show a Node's health (for debug use only)
     responses:
@@ -167,4 +167,4 @@ documentation:
           type: ErrorSchema
         headers:
           Location:
-            example: /x-nmos/registration/{version}/health/nodes/3b8be755-08ff-452b-b217-c9151eb21193/
+            example: /x-nmos/registration/{version}/health/nodes/3b8be755-08ff-452b-b217-c9151eb21193

--- a/APIs/RegistrationAPI.raml
+++ b/APIs/RegistrationAPI.raml
@@ -85,7 +85,6 @@ documentation:
       responses:
         200:
         403:
-        404:
     delete:
       description: Delete a registered resource
       responses:
@@ -131,7 +130,6 @@ documentation:
     responses:
       200:
       403:
-      404:
   post:
     description: Update Node health
     responses:


### PR DESCRIPTION
Follow up to #85.

I'm still unsure about using the same UUID for all resources in the example Location headers.
And I'd prefer the URLs to end without a trailing slash in all cases.

But for the moment, I've gone for consistency with the Query API examples.
