### PR TITLE
The "required" array in a JSON object schema MUST NOT be empty

### DIFF
--- a/APIs/schemas/nodeapi-receiver-target.json
+++ b/APIs/schemas/nodeapi-receiver-target.json
@@ -10,8 +10,6 @@
       "description": "Describes an empty object",
       "title": "Empty object schema",
       "additionalProperties": false,
-      "required": [
-      ],
       "properties": {
       }
     }


### PR DESCRIPTION
See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.3.1

Currently causes test suite to emit:
```
Traceback (most recent call last):
  File "E:\git\nmos-testing\nmostesting\GenericTest.py", line 152, in execute_test
    self.result.append(method(test))
  File "E:\git\nmos-testing\nmostesting\suites\IS0401Test.py", line 724, in test_13
    self.do_receiver_put(test, receiver["id"], request_data)
  File "E:\git\nmos-testing\nmostesting\suites\IS0401Test.py", line 1313, in do_receiver_put
    valid, message = self.check_response(schema, "PUT", put_response)
  File "E:\git\nmos-testing\nmostesting\GenericTest.py", line 288, in check_response
    self.validate_schema(response.json(), schema)
  File "E:\git\nmos-testing\nmostesting\GenericTest.py", line 313, in validate_schema
    jsonschema.validate(payload, schema, format_checker=checker)
  File "C:\Python35-32\lib\site-packages\jsonschema\validators.py", line 540, in validate
    cls.check_schema(schema)
  File "C:\Python35-32\lib\site-packages\jsonschema\validators.py", line 83, in check_schema
    raise SchemaError.create_from(error)
jsonschema.exceptions.SchemaError: [] is too short

Failed validating 'minItems' in schema['properties']['oneOf']['items']['properties']['required']:
    {'items': {'type': 'string'},
     'minItems': 1,
     'type': 'array',
     'uniqueItems': True}

On instance['oneOf'][1]['required']:
    []
```