### PR TITLE
Fix NSCnnn and Unn regexes

### DIFF
--- a/APIs/schemas/source_audio.json
+++ b/APIs/schemas/source_audio.json
@@ -67,11 +67,11 @@
                     ]
                   },
                   {
-                    "pattern": "NSC(0[0-9]{2}|1[0-1]{1}[0-9]{1}|12[0-7]{1})",
+                    "pattern": "^NSC(00[1-9]|0[1-9][0-9]|1[0-1][0-9]|12[0-7])$",
                     "description": "Numbered Source Channel"
                   },
                   {
-                    "pattern": "U(0[1-9]{1}|[1-5]{1}[0-9]{1}|6[0-4]{1})",
+                    "pattern": "^U(0[1-9]|[1-5][0-9]|6[0-4])$",
                     "description": "Undefined channel"
                   }
                 ]


### PR DESCRIPTION
The channel symbol regexes for Numbered Source Channel and Undefined are too lax.

Before this fix, the following would have been accepted:

* fooNSC001bar
* fooU01bar
* NSC000

Verified with the help of https://regex101.com/.
