### PR TITLE
Fixed bare URL links in Markdown

### DIFF
--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -6,7 +6,7 @@ _(c) AMWA 2016, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
 
 The documents included in this directory provide additional details and recommendations for implementations of the defined APIs, or their consumers.
 
-Familiarity with the JT-NM reference architecture (http://jt-nm.org/) is assumed, but a summary of the resources referenced by this specification is available in the [Data Model](5.0.%20Data%20Model.md).
+Familiarity with the JT-NM reference architecture (<http://jt-nm.org/>) is assumed, but a summary of the resources referenced by this specification is available in the [Data Model](5.0.%20Data%20Model.md).
 
 ## Introduction
 

--- a/docs/2.5. APIs - Query Parameters.md
+++ b/docs/2.5. APIs - Query Parameters.md
@@ -458,7 +458,7 @@ GET /x-nmos/query/v1.0/flows?tags.location=Salford&tags.location=London
 
 ## Advanced (RQL) Queries (Optional)
 
-Query APIs MAY support Resource Query Language (RQL https://github.com/persvr/rql/) queries against their API resources where the 'rql' trait is specified in the RAML documentation. A 501 HTTP status code MUST be returned where a RAML query is attempted using RQL functions or operators which are not supported by a Query API.
+Query APIs MAY support Resource Query Language (RQL, <https://github.com/persvr/rql/>) queries against their API resources where the 'rql' trait is specified in the RAML documentation. A 501 HTTP status code MUST be returned where a RAML query is attempted using RQL functions or operators which are not supported by a Query API.
 
 RQL should be formatted in the normalised form as opposed to using FIQL syntax, and passed via the query string using '?query.rql=...'.
 

--- a/docs/5.1. Data Model - Identifier Mapping.md
+++ b/docs/5.1. Data Model - Identifier Mapping.md
@@ -2,7 +2,7 @@
 
 _(c) AMWA 2016, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
 
-Identity is a core part of a flexible architecture for networked media. Associating IDs and timestamps with essence at the point of capture provides us with the capability to track a video frame or other content's ancestry through the production chain and back to the device which originally captured it. Definitions for each of the logical entities described here is available via the JT-NM Reference Architecture (http://www.jt-nm.org).
+Identity is a core part of a flexible architecture for networked media. Associating IDs and timestamps with essence at the point of capture provides us with the capability to track a video frame or other content's ancestry through the production chain and back to the device which originally captured it. Definitions for each of the logical entities described here is available via the JT-NM Reference Architecture (<http://www.jt-nm.org>).
 
 In order to ensure consistent behaviour in a production facility employing this identity, some rules must be applied when generating and handling identifiers. The guidelines below provide details of how this should be implemented.
 


### PR DESCRIPTION
Puts `<` and `>` around bare URLs so they render as links on github.io. See also https://github.com/AMWA-TV/nmos-template/issues/13