### PR TITLE
Link to MS-04 rather than old timing model.

### DIFF
--- a/docs/4.2. Behaviour - Querying.md
+++ b/docs/4.2. Behaviour - Querying.md
@@ -39,10 +39,14 @@ Using data Grains, the websocket protocol provides a client with the current sta
 
 Note that the Source ID used in the following examples references the Query API instance. The Flow ID then corresponds to the subscription ID created via the /subscriptions HTTP resource.
 
-The timestamps used in these messages relate to the [NMOS Content Model](https://github.com/AMWA-TV/nmos-content-model). In this use case the three timestamps are permitted to be identical.
+The timestamps used in these messages are as follows:
+
 *   creation_timestamp: The creation time of the Grain metadata which wraps the payload being exchanged.
 *   origin_timestamp: The capture or creation time of the payload being exchanged.
 *   sync_timestamp: Matches the origin_timestamp at the point of capture. This timestamp relates this payload to others which may take different processing paths. This may persist through processing devices which modify the payload's content.
+
+The three timestamps are permitted to be identical. For more details of the timing model used in NMOS specifications, see [MS-04](https://amwa-tv.github.io/nmos-id-timing-model/).
+
 
 The 'rate' and 'duration' attributes may be ignored by clients as the event messages being exchanged do not adhere to a defined rate or duration.
 


### PR DESCRIPTION
Removes need for workaround for https://github.com/AMWA-TV/nmos-discovery-registration/issues/135. 

Apologies for the name of the branch.