### PR TITLE
Adjust NSCnnn regex so that it can encompass 128 channels

### DIFF
--- a/APIs/schemas/source_audio.json
+++ b/APIs/schemas/source_audio.json
@@ -67,7 +67,7 @@
                     ]
                   },
                   {
-                    "pattern": "^NSC(00[1-9]|0[1-9][0-9]|1[0-1][0-9]|12[0-7])$",
+                    "pattern": "^NSC(0[0-9][0-9]|1[0-1][0-9]|12[0-8])$",
                     "description": "Numbered Source Channel"
                   },
                   {


### PR DESCRIPTION
(due to original regex allowing NSC000, but NSC001-NSC128 possibly being preferable for consistency with U01-U64, this version actually allows 129 values, see comments on #138 and #139)