### PR TITLE
[Editorial] Add explanation of efficient Registration API failover implied by heartbeating/garbage collection intervals

### DIFF
--- a/docs/4.1. Behaviour - Registration.md
+++ b/docs/4.1. Behaviour - Registration.md
@@ -34,7 +34,7 @@ In order to support this mode and ensure persistence in the registry upon link f
 
 ### Heartbeating
 
-Nodes are expected to peform a heartbeat every 5 seconds by default.
+Nodes are expected to perform a heartbeat every 5 seconds by default, by making HTTP POST requests to the `/health/nodes/{nodeId}` endpoint.
 
 Registration APIs should use a garbage collection interval of 12 seconds by default (triggered just after two failed heartbeats at the default 5 second interval).
 
@@ -110,4 +110,6 @@ A 500 error, inability to connect or a timeout indicates a server side or connec
 
 When performing the initial heartbeat with a new Registration API, a 200 code indicates that the Node and its resources are still present in the registry cluster and no further action is required. Future registrations and heartbeats should be performed against this new Registration API. If a 404 code is encountered when performing this heartbeat, refer to 'Node Encounters HTTP 404 On Heartbeat' above.
 
+Note that in order to achieve efficient failover from one Registration API to another, the Node needs to perform its first heartbeat with the new Registration API within the garbage collection interval following its most recent successful heartbeat. It is therefore recommended that Nodes use the heartbeat interval to define their connection timeouts for `/health/nodes/{nodeId}` POST requests.
+ 
 Should a 5xx error be encountered when interacting with all discoverable Registration APIs it is recommended that clients implement an exponential backoff algorithm in their next attempts until a non-5xx response code is received.


### PR DESCRIPTION
Clarification requested by implementers, already tested by the IS-04-01 test suite.

Backportable to previous minor versions.
