### PR TITLE
Example fixes v1.2.x

### DIFF
--- a/examples/nodeapi-self-get-200.json
+++ b/examples/nodeapi-self-get-200.json
@@ -4,7 +4,7 @@
     "caps": {},
     "href": "http://172.29.80.65:12345/",
     "api": {
-        "versions": ["v1.0", "v1.1"],
+        "versions": ["v1.0", "v1.1", "v1.2"],
         "endpoints": [
             {
                 "host": "172.29.80.65",
@@ -20,23 +20,23 @@
     },
     "services": [
         {
-            "href": "http://172.29.80.65:12345/x-manufacturer/pipelinemanager/",
+            "href": "https://172.29.80.65:443/x-manufacturer/pipelinemanager/",
             "type": "urn:x-manufacturer:service:pipelinemanager"
         },
         {
-            "href": "http://172.29.80.65:12345/x-manufacturer/status/",
+            "href": "https://172.29.80.65:443/x-manufacturer/status/",
             "type": "urn:x-manufacturer:service:status"
         },
         {
-            "href": "http://172.29.80.65:12345/x-manufacturer/tally/",
+            "href": "https://172.29.80.65:443/x-manufacturer/tally/",
             "type": "urn:x-manufacturer:service:tally"
         },
         {
-            "href": "http://172.29.80.65:12345/x-manufacturer/mdnsbridge/",
+            "href": "https://172.29.80.65:443/x-manufacturer/mdnsbridge/",
             "type": "urn:x-manufacturer:service:mdnsbridge"
         },
         {
-            "href": "http://172.29.80.65:12345/x-manufacturer/storequery/",
+            "href": "https://172.29.80.65:443/x-manufacturer/storequery/",
             "type": "urn:x-manufacturer:service:storequery"
         }
     ],

--- a/examples/queryapi-nodeid-get-200.json
+++ b/examples/queryapi-nodeid-get-200.json
@@ -6,7 +6,7 @@
     "tags": {},
     "href": "http://172.29.176.102:12345/",
     "api": {
-        "versions": ["v1.1"],
+        "versions": ["v1.1", "v1.2"],
         "endpoints": [
             {
                 "host": "172.29.176.102",

--- a/examples/queryapi-nodes-get-200.json
+++ b/examples/queryapi-nodes-get-200.json
@@ -7,7 +7,7 @@
         "tags": {},
         "href": "http://172.29.176.102:12345/",
         "api": {
-            "versions": ["v1.1"],
+            "versions": ["v1.1", "v1.2"],
             "endpoints": [
                 {
                     "host": "172.29.176.102",
@@ -63,7 +63,7 @@
         "tags": {},
         "href": "http://172.29.176.19:12345/",
         "api": {
-            "versions": ["v1.1"],
+            "versions": ["v1.1", "v1.2"],
             "endpoints": [
                 {
                     "host": "172.29.176.19",

--- a/examples/registrationapi-resource-get-200.json
+++ b/examples/registrationapi-resource-get-200.json
@@ -6,7 +6,7 @@
     "tags": {},
     "href": "http://172.29.80.65:12345/",
     "api": {
-        "versions": ["v1.0", "v1.1"],
+        "versions": ["v1.0", "v1.1", "v1.2"],
         "endpoints": [
             {
                 "host": "172.29.80.65",
@@ -22,23 +22,23 @@
     },
     "services": [
         {
-            "href": "http://172.29.80.65:12345/x-manufacturer/pipelinemanager/",
+            "href": "https://172.29.80.65:443/x-manufacturer/pipelinemanager/",
             "type": "urn:x-manufacturer:service:pipelinemanager"
         },
         {
-            "href": "http://172.29.80.65:12345/x-manufacturer/status/",
+            "href": "https://172.29.80.65:443/x-manufacturer/status/",
             "type": "urn:x-manufacturer:service:status"
         },
         {
-            "href": "http://172.29.80.65:12345/x-manufacturer/tally/",
+            "href": "https://172.29.80.65:443/x-manufacturer/tally/",
             "type": "urn:x-manufacturer:service:tally"
         },
         {
-            "href": "http://172.29.80.65:12345/x-manufacturer/mdnsbridge/",
+            "href": "https://172.29.80.65:443/x-manufacturer/mdnsbridge/",
             "type": "urn:x-manufacturer:service:mdnsbridge"
         },
         {
-            "href": "http://172.29.80.65:12345/x-manufacturer/storequery/",
+            "href": "https://172.29.80.65:443/x-manufacturer/storequery/",
             "type": "urn:x-manufacturer:service:storequery"
         }
     ],
@@ -56,6 +56,18 @@
             "version": "IEEE1588-2008",
             "gmid": "08-00-11-ff-fe-21-e1-b0",
             "locked": true
+        }
+    ],
+    "interfaces": [
+        {
+            "name":"eth0",
+            "chassis_id":"b3-cd-09-bb-9b-d8",
+            "port_id":"b3-cd-09-bb-9b-d8"
+        },
+        {
+            "name":"eth1",
+            "chassis_id":"b3-cd-09-bb-9b-d8",
+            "port_id":"b3-cd-09-bb-9b-d9"
         }
     ]
 }

--- a/examples/registrationapi-resource-post-200.json
+++ b/examples/registrationapi-resource-post-200.json
@@ -6,7 +6,7 @@
     "tags": {},
     "href": "http://172.29.80.65:12345/",
     "api": {
-        "versions": ["v1.0", "v1.1"],
+        "versions": ["v1.0", "v1.1", "v1.2"],
         "endpoints": [
             {
                 "host": "172.29.80.65",
@@ -22,23 +22,23 @@
     },
     "services": [
         {
-            "href": "http://172.29.80.65:12345/x-manufacturer/pipelinemanager/",
+            "href": "https://172.29.80.65:443/x-manufacturer/pipelinemanager/",
             "type": "urn:x-manufacturer:service:pipelinemanager"
         },
         {
-            "href": "http://172.29.80.65:12345/x-manufacturer/status/",
+            "href": "https://172.29.80.65:443/x-manufacturer/status/",
             "type": "urn:x-manufacturer:service:status"
         },
         {
-            "href": "http://172.29.80.65:12345/x-manufacturer/tally/",
+            "href": "https://172.29.80.65:443/x-manufacturer/tally/",
             "type": "urn:x-manufacturer:service:tally"
         },
         {
-            "href": "http://172.29.80.65:12345/x-manufacturer/mdnsbridge/",
+            "href": "https://172.29.80.65:443/x-manufacturer/mdnsbridge/",
             "type": "urn:x-manufacturer:service:mdnsbridge"
         },
         {
-            "href": "http://172.29.80.65:12345/x-manufacturer/storequery/",
+            "href": "https://172.29.80.65:443/x-manufacturer/storequery/",
             "type": "urn:x-manufacturer:service:storequery"
         }
     ],
@@ -56,6 +56,18 @@
             "version": "IEEE1588-2008",
             "gmid": "08-00-11-ff-fe-21-e1-b0",
             "locked": true
+        }
+    ],
+    "interfaces": [
+        {
+            "name":"eth0",
+            "chassis_id":"b3-cd-09-bb-9b-d8",
+            "port_id":"b3-cd-09-bb-9b-d8"
+        },
+        {
+            "name":"eth1",
+            "chassis_id":"b3-cd-09-bb-9b-d8",
+            "port_id":"b3-cd-09-bb-9b-d9"
         }
     ]
 }

--- a/examples/registrationapi-resource-post-request.json
+++ b/examples/registrationapi-resource-post-request.json
@@ -8,7 +8,7 @@
         "tags": {},
         "href": "http://172.29.80.65:12345/",
         "api": {
-            "versions": ["v1.0", "v1.1"],
+            "versions": ["v1.0", "v1.1", "v1.2"],
             "endpoints": [
                 {
                     "host": "172.29.80.65",
@@ -24,23 +24,23 @@
         },
         "services": [
             {
-                "href": "http://172.29.80.65:12345/x-manufacturer/pipelinemanager/",
+                "href": "https://172.29.80.65:443/x-manufacturer/pipelinemanager/",
                 "type": "urn:x-manufacturer:service:pipelinemanager"
             },
             {
-                "href": "http://172.29.80.65:12345/x-manufacturer/status/",
+                "href": "https://172.29.80.65:443/x-manufacturer/status/",
                 "type": "urn:x-manufacturer:service:status"
             },
             {
-                "href": "http://172.29.80.65:12345/x-manufacturer/tally/",
+                "href": "https://172.29.80.65:443/x-manufacturer/tally/",
                 "type": "urn:x-manufacturer:service:tally"
             },
             {
-                "href": "http://172.29.80.65:12345/x-manufacturer/mdnsbridge/",
+                "href": "https://172.29.80.65:443/x-manufacturer/mdnsbridge/",
                 "type": "urn:x-manufacturer:service:mdnsbridge"
             },
             {
-                "href": "http://172.29.80.65:12345/x-manufacturer/storequery/",
+                "href": "https://172.29.80.65:443/x-manufacturer/storequery/",
                 "type": "urn:x-manufacturer:service:storequery"
             }
         ],
@@ -58,6 +58,18 @@
                 "version": "IEEE1588-2008",
                 "gmid": "08-00-11-ff-fe-21-e1-b0",
                 "locked": true
+            }
+        ],
+        "interfaces": [
+            {
+                "name":"eth0",
+                "chassis_id":"b3-cd-09-bb-9b-d8",
+                "port_id":"b3-cd-09-bb-9b-d8"
+            },
+            {
+                "name":"eth1",
+                "chassis_id":"b3-cd-09-bb-9b-d8",
+                "port_id":"b3-cd-09-bb-9b-d9"
             }
         ]
     }


### PR DESCRIPTION
Backports #156 to v1.2.x, especially to fix missing Node "interfaces" that have been required since v1.2.

JSON Schema validation run on all examples locally.
(Also run for v1.1.x which passed without requiring any changes.)