### PR TITLE
Use backticks to render URLs etc as monospaced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.swp
 *~
 .DS_Store
+output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ This document provides an overview of changes between released versions of this 
 * Deprecate mDNS announcements for Nodes in registered mode
 * Replace DNS-SD service type for Registration API
 * Permit deprecated Node API connection management to not be implemented
-* Add explicit requirements for 501 responses when features are not implemented
+* Add explicit requirements for 501 (Not Implemented) responses when features are not implemented
 * Add support for future device and transport types
 * Permit a Sender's `manifest_href` to be `null` when the transport type does not require a transport file
-* Add 409 response code for registries with conflicting resources
+* Add 409 (Conflict) response code for registries with conflicting resources
 * Add support for signalling authorization requirements
 * Indicate potential for Source/Flow attributes and `caps` to be defined externally in the future
 * Revise discovery process to ignore mDNS records when unicast records are available

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ This document provides an overview of changes between released versions of this 
 * Permit deprecated Node API connection management to not be implemented
 * Add explicit requirements for 501 responses when features are not implemented
 * Add support for future device and transport types
-* Permit a Sender's 'manifest_href' to be null when the transport type does not require a transport file
+* Permit a Sender's `manifest_href` to be `null` when the transport type does not require a transport file
 * Add 409 response code for registries with conflicting resources
 * Add support for signalling authorization requirements
-* Indicate potential for Source/Flow attributes and 'caps' to be defined externally in the future
+* Indicate potential for Source/Flow attributes and `caps` to be defined externally in the future
 * Revise discovery process to ignore mDNS records when unicast records are available
 
 ## Release v1.2
@@ -21,20 +21,20 @@ This document provides an overview of changes between released versions of this 
 * Add signalling for active connections to unicast Senders, or non-NMOS Devices
 
 ## Release v1.1
-* Add multi-protocol support and version identification to Node API /self and hence Query API /nodes
-* Add 'api\_proto' TXT records to DNS-SD advertisements
-* Add 'api\_ver' TXT records to DNS-SD advertisements
+* Add multi-protocol support and version identification to Node API `/self` and hence Query API `/nodes`
+* Add `api_proto` TXT records to DNS-SD advertisements
+* Add `api_ver` TXT records to DNS-SD advertisements
 * Add guidance on use of DNS SRV record priority and weight
 * Add support for secure websockets to the Query API
-* Add support for Upgrade headers when using websockets
+* Add support for `Upgrade` headers when using websockets
 * Add paging support to the Query API
 * Add advanced query parameter support for the Query API
-* Add 'device\_id' to Flow attributes covering cases where a Device is a content transformer only
+* Add `device_id` to Flow attributes covering cases where a Device is a content transformer only
 * Permit Senders without attached Flows to model a Device before internal routing has been performed
 * Add support for exposing control endpoints from Devices
 * Add support for muxed Sources and Flows (TR-04 and 2022-6)
 * Add attributes for Sources and Flows for TR-03 set of media streams (raw video, raw audio, anc data)
-* Ensure all API resources consistently advertise a 'label', 'description' and 'tags'
+* Ensure all API resources consistently advertise a `label`, `description` and `tags`
 * Add support for signalling clocks exposed by Nodes and used by Sources
 
 ## Release v1.0

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -70,9 +70,9 @@ Registered discovery takes place using a **Registration & Discovery System (RDS)
 
 ![Registration and Discovery](images/registration-and-discovery.png)
 
-The Registration Service implements the Registration API of the NMOS Discovery and Registration Specification. Nodes POST to this API to register themselves and their resources. The Registration Service also manages garbage collection of Nodes and their resources by requiring Nodes to send regular keep-alive/heartbeat messages.
+The Registration Service implements the Registration API of the NMOS Discovery and Registration Specification. Nodes `POST` to this API to register themselves and their resources. The Registration Service also manages garbage collection of Nodes and their resources by requiring Nodes to send regular keep-alive/heartbeat messages.
 
-The Query Service implements the Query API of the NMOS Discovery and Registration Specification. Clients can GET lists of resources from this API. Typical usage examples include:
+The Query Service implements the Query API of the NMOS Discovery and Registration Specification. Clients can `GET` lists of resources from this API. Typical usage examples include:
 
 - Obtaining a list of registered Nodes in order to drive a configuration interface.
 - Obtaining a list of Sender resources and a list of Receiver resources in order to provide a connection management interface.

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -27,7 +27,7 @@ All APIs MUST provide a JSON representation signalled via `Content-Type: applica
 
 ### API Paths
 
-All NMOS APIs MUST use a path in the following format. Other HTTP resources MAY be presented on the same port by the Node, provided all NMOS resources are available from the /x-nmos/ path as follows:
+All NMOS APIs MUST use a path in the following format. Other HTTP resources MAY be presented on the same port by the Node, provided all NMOS resources are available from the `/x-nmos/` path as follows:
 
 ```
 http(s)://<ip address or hostname>:<port>/x-nmos/<api type>/<api version>/

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -111,6 +111,6 @@ For HTTP codes 400 and upwards, a JSON format response MUST be returned as follo
 }
 ```
 
-`code` SHOULD match the HTTP status code. `error` MUST always be present and in string format. `debug` MAY be null if no further debug information is available.
+`code` SHOULD match the HTTP status code. `error` MUST always be present and in string format. `debug` MAY be `null` if no further debug information is available.
 
 Further details on when APIs will respond with particular codes is covered in the [Behaviour](4.0.%20Behaviour.md) section.

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -35,9 +35,9 @@ http(s)://<ip address or hostname>:<port>/x-nmos/<api type>/<api version>/
 
 At each level of the API from the base resource upwards, the response SHOULD include a JSON format array of the child resources available from that point.
 
-API clients using DNS-SD for API discovery SHOULD construct these paths by making use of the TXT records 'api\_proto' and 'api\_ver', along with addresses and ports resolved via DNS-SD. API clients which are discovering Node APIs via a Query API SHOULD construct Node API paths using the corresponding data available within the `api` attributes within the Query API `/nodes/` path.
+API clients using DNS-SD for API discovery SHOULD construct these paths by making use of the TXT records `api_proto` and `api_ver`, along with addresses and ports resolved via DNS-SD. API clients which are discovering Node APIs via a Query API SHOULD construct Node API paths using the corresponding data available within the `api` attributes within the Query API `/nodes/` path.
 
-Where protocol and versioning data is not available, clients MAY assume a v1.0 API, which operates via the `http` protocol only.
+Where protocol and versioning data is not available, clients MAY assume a v1.0 API, which operates via HTTP only.
 
 ### Versioning
 
@@ -69,7 +69,7 @@ A v1.1 API response can include:
 - The versioning format is `v<#MAJOR>.<#MINOR>`
 - MINOR increments will be performed for non-breaking changes (such as the addition of attributes in a response)
 - MAJOR increments will be performed for breaking changes (such as the renaming of a resource or attribute)
-- Versions MUST be represented as complete strings. Parsing MUST proceed as follows: separate into two strings, using the point (.) as a delimiter. Compare integer representations of MAJOR, MINOR version (such that v1.12 is greater than v1.5).
+- Versions MUST be represented as complete strings. Parsing MUST proceed as follows: separate into two strings, using the point (`.`) as a delimiter. Compare integer representations of MAJOR, MINOR version (such that v1.12 is greater than v1.5).
 - Clients are responsible for identifying the correct API version they require.
 
 ### URLs: Approach to Trailing Slashes

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -29,20 +29,21 @@ All APIs MUST provide a JSON representation signalled via 'Content-Type: applica
 
 All NMOS APIs MUST use a path in the following format. Other HTTP resources MAY be presented on the same port by the Node, provided all NMOS resources are available from the /x-nmos/ path as follows:
 
+```
 http(s)://<ip address or hostname>:<port>/x-nmos/<api type>/<api version>/
 ```
 
 At each level of the API from the base resource upwards, the response SHOULD include a JSON format array of the child resources available from that point.
 
-API clients using DNS-SD for API discovery SHOULD construct these paths by making use of the TXT records 'api\_proto' and 'api\_ver', along with addresses and ports resolved via DNS-SD. API clients which are discovering Node APIs via a Query API SHOULD construct Node API paths using the corresponding data available within the \'api\' attributes within the Query API /nodes/ path.
+API clients using DNS-SD for API discovery SHOULD construct these paths by making use of the TXT records 'api\_proto' and 'api\_ver', along with addresses and ports resolved via DNS-SD. API clients which are discovering Node APIs via a Query API SHOULD construct Node API paths using the corresponding data available within the `api` attributes within the Query API `/nodes/` path.
 
-Where protocol and versioning data is not available, clients MAY assume a v1.0 API, which operates via the 'http' protocol only.
+Where protocol and versioning data is not available, clients MAY assume a v1.0 API, which operates via the `http` protocol only.
 
 ### Versioning
 
 All public APIs are versioned as follows:
 
-- Requesting the API base resource (such as http(s)://&lt;ip address or hostname&gt;:&lt;port&gt;/x-nmos/query/) will provide a list containing the versions of the API present on the node.
+- Requesting the API base resource (such as `http(s)://<ip address or hostname>/x-nmos/query/`) will provide a list containing the versions of the API present on the node.
 - A versioned API response MUST include only resources which match the schema for that API version.
 - Data which is held for mismatched minor API versions MAY be returned if it can be conformed to the correct schema (see example below). Data MUST NOT be conformed between major API versions.
 
@@ -64,8 +65,8 @@ A v1.1 API response can include:
 ]
 ```
 
-- Appending /v1.0/ to the API base resource will request version 1.0 of the API if available.
-- The versioning format is v&lt;#MAJOR&gt;.&lt;#MINOR&gt;
+- Appending `/v1.0/` to the API base resource will request version 1.0 of the API if available.
+- The versioning format is `v<#MAJOR>.<#MINOR>`
 - MINOR increments will be performed for non-breaking changes (such as the addition of attributes in a response)
 - MAJOR increments will be performed for breaking changes (such as the renaming of a resource or attribute)
 - Versions MUST be represented as complete strings. Parsing MUST proceed as follows: separate into two strings, using the point (.) as a delimiter. Compare integer representations of MAJOR, MINOR version (such that v1.12 is greater than v1.5).
@@ -92,7 +93,7 @@ In order to overcome shortcomings in some common libraries, the following requir
 
 #### Client Behaviour
 
-When a server implementation needs to indicate an API URL via an 'href' or similar attribute, it is valid to either include a trailing slash or not provided that the listed path is accessible and follows the above rules. Clients appending paths to 'href' type attributes MUST support both cases, avoiding doubled or missing slashes.
+When a server implementation needs to indicate an API URL via an `href` or similar attribute, it is valid to either include a trailing slash or not provided that the listed path is accessible and follows the above rules. Clients appending paths to `href` type attributes MUST support both cases, avoiding doubled or missing slashes.
 
 ### Error Codes & Responses
 
@@ -110,6 +111,6 @@ For HTTP codes 400 and upwards, a JSON format response MUST be returned as follo
 }
 ```
 
-The 'code' SHOULD match the HTTP status code. 'error' MUST always be present and in string format. 'debug' MAY be null if no further debug information is available.
+`code` SHOULD match the HTTP status code. `error` MUST always be present and in string format. `debug` MAY be null if no further debug information is available.
 
 Further details on when APIs will respond with particular codes is covered in the [Behaviour](4.0.%20Behaviour.md) section.

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -19,7 +19,7 @@ Examples of JSON format output are provided in the [examples](../examples/) fold
 
 ## API Validation
 
-JSON schemas are included with the RAML API definitions. These include validation for values used within the APIs. It is strongly RECOMMENDED that implementers of a Registration API use these JSON schemas as part of a validation stage when receiving registrations from Nodes. Invalid resources SHOULD cause a 400 HTTP error (Bad Request) to be returned to the client.
+JSON schemas are included with the RAML API definitions. These include validation for values used within the APIs. It is strongly RECOMMENDED that implementers of a Registration API use these JSON schemas as part of a validation stage when receiving registrations from Nodes. Invalid resources SHOULD cause a 400 (Bad Request) HTTP error to be returned to the client.
 
 ### Content Types
 

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -23,7 +23,7 @@ JSON schemas are included with the RAML API definitions. These include validatio
 
 ### Content Types
 
-All APIs MUST provide a JSON representation signalled via 'Content-Type: application/json' headers. This SHOULD be the default content type in the absence of any requested alternative by clients. Other content types (such as HTML) are permitted if they are explicitly requested via Accept headers.
+All APIs MUST provide a JSON representation signalled via `Content-Type: application/json` headers. This SHOULD be the default content type in the absence of any requested alternative by clients. Other content types (such as HTML) are permitted if they are explicitly requested via Accept headers.
 
 ### API Paths
 

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -78,13 +78,13 @@ For consistency and in order to adhere to how these APIs are specified in RAML, 
 
 In order to overcome shortcomings in some common libraries, the following requirements are imposed for the support of URL paths with or without trailing slashes.
 
-#### GET and HEAD Requests
+#### `GET` and `HEAD` Requests
 
 - Clients performing requests using these methods SHOULD correctly handle a 301 response (moved permanently).
 - When a 301 is supported, the client MUST follow the redirect in order to retrieve the response payload.
 - Servers implementing the APIs MUST support requests using these methods to both the trailing slash and non-trailing slash path to each resource. One of these MAY produce a 301 response causing a redirect to the other if preferred.
 
-#### All Other Requests (PUT, POST, DELETE, OPTIONS etc)
+#### All Other Requests (`PUT`, `POST`, `DELETE`, `OPTIONS`, etc)
 
 - Clients performing requests using these methods MUST use URLs with no trailing slash present.
 - Servers implementing the APIs MUST correctly interpret requests using these methods to paths without trailing slashes present.

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -35,7 +35,7 @@ http(s)://<ip address or hostname>:<port>/x-nmos/<api type>/<api version>/
 
 At each level of the API from the base resource upwards, the response SHOULD include a JSON format array of the child resources available from that point.
 
-API clients using DNS-SD for API discovery SHOULD construct these paths by making use of the TXT records `api_proto` and `api_ver`, along with addresses and ports resolved via DNS-SD. API clients which are discovering Node APIs via a Query API SHOULD construct Node API paths using the corresponding data available within the `api` attributes within the Query API `/nodes/` path.
+API clients using DNS-SD for API discovery SHOULD construct these paths by making use of the TXT records `api_proto` and `api_ver`, along with addresses and ports resolved via DNS-SD. API clients which are discovering Node APIs via a Query API SHOULD construct Node API paths using the corresponding data available within the `api` attributes within the Query API `/nodes` resources.
 
 Where protocol and versioning data is not available, clients MAY assume a v1.0 API, which operates via HTTP only.
 

--- a/docs/2.1. APIs - Common Keys.md
+++ b/docs/2.1. APIs - Common Keys.md
@@ -6,9 +6,9 @@ A number of common keys are used within NMOS APIs. Their definitions, semantics 
 
 ## Version
 
-Core resources such as Sources, Flows, Nodes etc. include a 'version' attribute. As properties of a given Flow or similar will change over its lifetime, the version identifies the instant at which this change took place. For example, if a vision mix transition occurred which resulted in a change to the 'parents' which make up a particular Flow, the 'version' is modified to reflect the wall clock instant at which this change occurred.
+Core resources such as Sources, Flows, Nodes etc. include a `version` attribute. As properties of a given Flow or similar will change over its lifetime, the version identifies the instant at which this change took place. For example, if a vision mix transition occurred which resulted in a change to the `parents` which make up a particular Flow, the `version` is modified to reflect the wall clock instant at which this change occurred.
 
-The version is a nanosecond TAI timestamp represented as a string of the format: &lt;seconds&gt;:&lt;nanoseconds&gt;. Note the ':' as opposed to a '.', indicating that the value '1439299836:10' is interpreted as 1439299836 seconds and 10 nanoseconds.
+`version` is a nanosecond TAI timestamp represented as a string of the format: `<seconds>:<nanoseconds`. Note the  `:` as opposed to a `.`, indicating that the value `1439299836:10` is interpreted as 1439299836 seconds and 10 nanoseconds.
 
 Combining the version with the resource's ID attribute creates a hash which can be used to uniquely identify a particular variant of a Source, Flow or similar.
 
@@ -24,12 +24,12 @@ Freeform human readable string to be used within user interfaces.
 
 A URN describing the data format of a video, audio or data flow.
 
-| **Permitted Value**     | **Valid From API Version** |
-|-------------------------|----------------------------|
-| urn:x-nmos:format:video | v1.0                       |
-| urn:x-nmos:format:audio | v1.0                       |
-| urn:x-nmos:format:data  | v1.0                       |
-| urn:x-nmos:format:mux   | v1.1                       |
+| **Permitted Value**       | **Valid From API Version** |
+|---------------------------|----------------------------|
+| `urn:x-nmos:format:video` | v1.0                       |
+| `urn:x-nmos:format:audio` | v1.0                       |
+| `urn:x-nmos:format:data`  | v1.0                       |
+| `urn:x-nmos:format:mux `  | v1.1                       |
 
 See [Use of URNs](#use-of-urns) below for additional requirements regarding their handling.
 
@@ -39,14 +39,14 @@ A URN describing the protocol used to send data (video, audio, data etc.) over a
 
 Note: From v1.3 onwards, permitted transport types are not versioned and are instead defined via the [NMOS Parameter Registers](https://github.com/AMWA-TV/nmos-parameter-registers). Prior to v1.3, the following table applies.
 
-| **Permitted Value**            | **Valid From API Version** |
-|--------------------------------|----------------------------|
-| urn:x-nmos:transport:rtp       | v1.0                       |
-| urn:x-nmos:transport:rtp.mcast | v1.0                       |
-| urn:x-nmos:transport:rtp.ucast | v1.0                       |
-| urn:x-nmos:transport:dash      | v1.0                       |
+| **Permitted Value**              | **Valid From API Version** |
+|----------------------------------|----------------------------|
+| `urn:x-nmos:transport:rtp`       | v1.0                       |
+| `urn:x-nmos:transport:rtp.mcast` | v1.0                       |
+| `urn:x-nmos:transport:rtp.ucast` | v1.0                       |
+| `urn:x-nmos:transport:dash`      | v1.0                       |
 
-For example, an RTP Transmitter sending to a multicast group uses the transport 'urn:x-nmos:transport:rtp.mcast', but a receiver supporting both unicast and multicast presents the transport 'urn:x-nmos:transport:rtp' to indicate its less restrictive state.
+For example, an RTP Transmitter sending to a multicast group uses the transport `urn:x-nmos:transport:rtp.mcast`, but a receiver supporting both unicast and multicast presents the transport `urn:x-nmos:transport:rtp` to indicate its less restrictive state.
 
 See [Use of URNs](#use-of-urns) below for additional requirements regarding their handling.
 
@@ -72,33 +72,33 @@ A URN describing the role which a Device has within the production environment (
 
 Note: From v1.3 onwards, permitted device types are not versioned and are instead defined via the [NMOS Parameter Registers](https://github.com/AMWA-TV/nmos-parameter-registers). Prior to v1.3, the following table applies.
 
-| **Permitted Value**        | **Valid From API Version** |
-|----------------------------|----------------------------|
-| urn:x-nmos:device:generic  | v1.0                       |
-| urn:x-nmos:device:pipeline | v1.0                       |
+| **Permitted Value**          | **Valid From API Version** |
+|------------------------------|----------------------------|
+| `urn:x-nmos:device:generic`  | v1.0                       |
+| `urn:x-nmos:device:pipeline` | v1.0                       |
 
 See [Use of URNs](#use-of-urns) below for additional requirements regarding their handling.
 
 ## Use of URNs
 
-All Uniform Resource Names (URNs) specified within the scope of the NMOS specifications MUST use the namespace 'urn:x-nmos:'. Manufacturers MAY use their own namespaces to indicate values of URN which are not currently defined within the NMOS namespace.
+All Uniform Resource Names (URNs) specified within the scope of the NMOS specifications MUST use the namespace `urn:x-nmos:`. Manufacturers MAY use their own namespaces to indicate values of URN which are not currently defined within the NMOS namespace.
 
-Where a URN begins 'urn:x-nmos:' it MUST use the following construction:
+Where a URN begins `urn:x-nmos:` it MUST use the following construction:
 
-- The URN 'base' is a sequence of one or more names delimited by ':' characters, including the namespace
+- The URN `base` is a sequence of one or more names delimited by `:` characters, including the namespace
 - The URN MAY include one or more 'subclassifications'
 - The URN MAY include a version number
 
-Subclassifications are defined as the portion of the URN which follows the first occurrence of a '.', but prior to any '/' character. By convention, URNs which begin 'urn:x-nmos:' will never include a further ':' after the first occurrence of a '.'.
+Subclassifications are defined as the portion of the URN which follows the first occurrence of a `.`, but prior to any `/` character. By convention, URNs which begin `urn:x-nmos:` will never include a further `:` after the first occurrence of a `.`.
 
-For example, the URN base 'urn:x-nmos:transport:rtp' above has two subclassifications of 'ucast' and 'mcast'.
+For example, the URN base `urn:x-nmos:transport:rtp` above has two subclassifications of `ucast` and `mcast`.
 
-API clients interpreting URNs MUST correctly recognise any as-yet undefined subclassifications as being associated with the URN base which appears prior to the first '.' character.
+API clients interpreting URNs MUST correctly recognise any as-yet undefined subclassifications as being associated with the URN base which appears prior to the first `.` character.
 
-For example, if filtering by the format 'urn:x-nmos:format:video', the filter includes any as-yet undefined subclassifications such as 'urn:x-nmos:format:video.raw'.
+For example, if filtering by the format `urn:x-nmos:format:video`, the filter includes any as-yet undefined subclassifications such as `urn:x-nmos:format:video.raw`.
 
-Versions are defined as the portion of the URN which follows the first occurrence of a '/', up to and including the remainder of the URN. Any '.' characters after this point indicate a version delimiter. By convention, URNs which begin 'urn:x-nmos:' will format the version as 'v<#MAJOR>.<#MINOR>' and SHOULD be handled as specified in [APIs](2.0.%20APIs.md).
+Versions are defined as the portion of the URN which follows the first occurrence of a `/`, up to and including the remainder of the URN. Any `.` characters after this point indicate a version delimiter. By convention, URNs which begin `urn:x-nmos:` will format the version as `v<#MAJOR>.<#MINOR>` and SHOULD be handled as specified in [APIs](2.0.%20APIs.md).
 
-For example, the URN 'urn:x-nmos:control:sr-ctrl/v1.0' can be separated into a base 'urn:x-nmos:control:sr-ctrl' and version 'v1.0'.
+For example, the URN `urn:x-nmos:control:sr-ctrl/v1.0` can be separated into a base `urn:x-nmos:control:sr-ctrl` and version `v1.0`.
 
 Query API clients MUST be tolerant to URNs which have not yet been defined, but which might be added in later API versions.

--- a/docs/2.1. APIs - Common Keys.md
+++ b/docs/2.1. APIs - Common Keys.md
@@ -85,7 +85,7 @@ All Uniform Resource Names (URNs) specified within the scope of the NMOS specifi
 
 Where a URN begins `urn:x-nmos:` it MUST use the following construction:
 
-- The URN `base` is a sequence of one or more names delimited by `:` characters, including the namespace
+- The URN base is a sequence of one or more names delimited by `:` characters, including the namespace
 - The URN MAY include one or more 'subclassifications'
 - The URN MAY include a version number
 

--- a/docs/2.1. APIs - Common Keys.md
+++ b/docs/2.1. APIs - Common Keys.md
@@ -29,7 +29,7 @@ A URN describing the data format of a video, audio or data flow.
 | `urn:x-nmos:format:video` | v1.0                       |
 | `urn:x-nmos:format:audio` | v1.0                       |
 | `urn:x-nmos:format:data`  | v1.0                       |
-| `urn:x-nmos:format:mux `  | v1.1                       |
+| `urn:x-nmos:format:mux`   | v1.1                       |
 
 See [Use of URNs](#use-of-urns) below for additional requirements regarding their handling.
 

--- a/docs/2.2. APIs - Client Side Implementation Notes.md
+++ b/docs/2.2. APIs - Client Side Implementation Notes.md
@@ -12,4 +12,4 @@ The NMOS Registration and Query APIs are designed to be highly available and sup
 
 ## Empty Request Bodies
 
-A number of API resources specify HTTP requests with no request body (headers only). These commonly include HTTP GET, HEAD, OPTIONS and DELETE operations, but could include other HTTP methods in some circumstances. When performing API requests which have no specified request body schema, clients SHOULD NOT send any body payload and SHOULD NOT set the HTTP `Content-Type` header. Clients MAY set the `Content-Length` header to a value of `0` to indicate this empty body, but this is not mandated.
+A number of API resources specify HTTP requests with no request body (headers only). These commonly include HTTP `GET`, `HEAD`, `OPTIONS` and `DELETE` operations, but could include other HTTP methods in some circumstances. When performing API requests which have no specified request body schema, clients SHOULD NOT send any body payload and SHOULD NOT set the HTTP `Content-Type` header. Clients MAY set the `Content-Length` header to a value of `0` to indicate this empty body, but this is not mandated.

--- a/docs/2.3. APIs - Server Side Implementation Notes.md
+++ b/docs/2.3. APIs - Server Side Implementation Notes.md
@@ -6,7 +6,7 @@ _(c) AMWA 2016, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 In order to permit web-based control interfaces to be hosted remotely, all NMOS APIs MUST implement valid CORS HTTP headers in responses to all requests.
 
-In addition to this, where highlighted in the API specifications servers MUST respond to HTTP pre-flight OPTIONS requests. Servers MAY additionally support HTTP OPTIONS requests made to any other API resource.
+In addition to this, where highlighted in the API specifications servers MUST respond to HTTP pre-flight `OPTIONS` requests. Servers MAY additionally support HTTP ``OPTIONS requests made to any other API resource.
 
 In order to simplify development, the following headers MAY be returned in order to remove these restrictions as far as possible. Note that these are very relaxed and possibly not suitable for a production deployment.
 

--- a/docs/2.3. APIs - Server Side Implementation Notes.md
+++ b/docs/2.3. APIs - Server Side Implementation Notes.md
@@ -17,12 +17,12 @@ Access-Control-Allow-Headers: Content-Type, Accept
 Access-Control-Max-Age: 3600
 ```
 
-To ensure compatibility, the response 'Access-Control-Allow-Headers' could be set from the request's 'Access-Control-Request-Headers'.
+To ensure compatibility, the response `Access-Control-Allow-Headers` could be set from the request's `Access-Control-Request-Headers`.
 
-## Use of '.local' Hostnames
+## Use of `.local` Hostnames
 
-Where 'href' or 'host' attributes are specified in the APIs, it is strongly RECOMMENDED to use either IP addresses or hostnames which are resolvable using unicast DNS. Whilst '.local' hostnames are convenient in a zero-configuration layer 2 network segment, these are not usually resolvable beyond these boundaries. As this specification is intended for use between layer 3 network segments, use of these hostnames can result in Nodes appearing inaccessible.
+Where `href` or `host` attributes are specified in the APIs, it is strongly RECOMMENDED to use either IP addresses or hostnames which are resolvable using unicast DNS. Whilst `.local` hostnames are convenient in a zero-configuration layer 2 network segment, these are not usually resolvable beyond these boundaries. As this specification is intended for use between layer 3 network segments, use of these hostnames can result in Nodes appearing inaccessible.
 
 ## Node API Senders: Use with RTP
 
-When using RTP for a sender, the 'manifest_href' MUST be an HTTP-accessible reference to an SDP file. As per [RFC 4566](https://tools.ietf.org/html/rfc4566), SDP files advertised via web services SHOULD use a MIME type of 'application/sdp'.
+When using RTP for a sender, the `manifest_href` MUST be an HTTP-accessible reference to an SDP file. As per [RFC 4566](https://tools.ietf.org/html/rfc4566), SDP files advertised via web services SHOULD use a MIME type of `application/sdp`.

--- a/docs/2.3. APIs - Server Side Implementation Notes.md
+++ b/docs/2.3. APIs - Server Side Implementation Notes.md
@@ -6,7 +6,7 @@ _(c) AMWA 2016, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 In order to permit web-based control interfaces to be hosted remotely, all NMOS APIs MUST implement valid CORS HTTP headers in responses to all requests.
 
-In addition to this, where highlighted in the API specifications servers MUST respond to HTTP pre-flight `OPTIONS` requests. Servers MAY additionally support HTTP ``OPTIONS requests made to any other API resource.
+In addition to this, where highlighted in the API specifications servers MUST respond to HTTP pre-flight `OPTIONS` requests. Servers MAY additionally support HTTP `OPTIONS` requests made to any other API resource.
 
 In order to simplify development, the following headers MAY be returned in order to remove these restrictions as far as possible. Note that these are very relaxed and possibly not suitable for a production deployment.
 

--- a/docs/2.4. APIs - Load Balancing & Redundancy.md
+++ b/docs/2.4. APIs - Load Balancing & Redundancy.md
@@ -19,4 +19,4 @@ _(c) AMWA 2016, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 ### Low Powered Devices
 
-Low powered Nodes MAY be deployed with an HTTP caching layer in front of them to support demanding use cases. It is suggested as a result that manufacturers of such devices provide the option for the user to manually replace the hostname used by the device in any 'href' attributes exposed in APIs and registrations. By replacing this hostname with the location of the cache layer, this load can be managed externally to the device.
+Low powered Nodes MAY be deployed with an HTTP caching layer in front of them to support demanding use cases. It is suggested as a result that manufacturers of such devices provide the option for the user to manually replace the hostname used by the device in any `href` attributes exposed in APIs and registrations. By replacing this hostname with the location of the cache layer, this load can be managed externally to the device.

--- a/docs/2.5. APIs - Query Parameters.md
+++ b/docs/2.5. APIs - Query Parameters.md
@@ -249,7 +249,7 @@ Payload Resources
 
 When a client requests data which falls at the extreme ends of the stored data set it can be less clear what values SHOULD be returned in the `X-Paging-Limit` and `X-Paging-Since` headers. The following examples are intended to clarify these cases.
 
-Where a paging limit is not specified in a request the server`s default is used.
+Where a paging limit is not specified in a request the server's default is used.
 
 **Example 1: Client request occurs at the beginning of the data set**
 

--- a/docs/2.5. APIs - Query Parameters.md
+++ b/docs/2.5. APIs - Query Parameters.md
@@ -480,7 +480,7 @@ GET /x-nmos/query/v1.0/sources?format=urn:x-nmos:format:video&device_id=9126cc2f
 
 ***Response***
 
-- Returns all Source objects which have an attribute of `format` which exactly matches `urn:x-nmos:format:video` AND a `device_id` attribute which exactly matches `9126cc2f-4c26-4c9b-a6cd-93c4381c9be5`.
+- Returns all Source objects which have an attribute of `format` which exactly matches `urn:x-nmos:format:video` and a `device_id` attribute which exactly matches `9126cc2f-4c26-4c9b-a6cd-93c4381c9be5`.
 
 **Example 3: Querying Within Objects**
 

--- a/docs/2.5. APIs - Query Parameters.md
+++ b/docs/2.5. APIs - Query Parameters.md
@@ -8,34 +8,34 @@ The following document describes the expected usage and behaviour of these query
 
 ## Pagination
 
-Query APIs SHOULD support pagination of their API resources where the 'paged' trait is specified in the RAML documentation. A 501 HTTP status code MUST be returned where pagination is attempted against a Query API which does not implement it. Pagination is not used by WebSocket subscriptions.
+Query APIs SHOULD support pagination of their API resources where the `paged` trait is specified in the RAML documentation. A 501 HTTP status code MUST be returned where pagination is attempted against a Query API which does not implement it. Pagination is not used by WebSocket subscriptions.
 
-Query API clients MUST detect whether pagination is being used by examining the HTTP response headers for 'X-Paging-Limit' which MUST be returned in all cases where pagination is in use.
+Query API clients MUST detect whether pagination is being used by examining the HTTP response headers for `X-Paging-Limit` which MUST be returned in all cases where pagination is in use.
 
-The registry which backs the Query API SHOULD maintain a 'creation' and 'update' timestamp alongside each registered resource. These values SHOULD NOT be returned to API clients in the response body, but will be made available via headers and used as pagination cursors.
+The registry which backs the Query API SHOULD maintain a `creation` and `update` timestamp alongside each registered resource. These values SHOULD NOT be returned to API clients in the response body, but will be made available via headers and used as pagination cursors.
 
 To ensure that pagination does not result in resources being skipped, there SHOULD NOT be duplicate creation or update timestamps stored against resources of the same type (Node, Source, Flow, etc.). It is RECOMMENDED that these timestamps are stored with nanosecond resolution using a TAI timebase, which will allow clients to navigate collections based on a common understanding of time.
 
-The choice to page based on 'creation' or 'update' timestamp SHOULD depend on the client's intended use of the data:
+The choice to page based on `creation` or `update` timestamp SHOULD depend on the client's intended use of the data:
 
-- Paging based on 'creation' time from the start of a collection provides the best mechanism to identify all resources held in a registry.
-- Paging based on 'update' time from the end of a collection provides the best mechanism to watch for changing resources in the case that WebSocket subscriptions are not available.
+- Paging based on `creation` time from the start of a collection provides the best mechanism to identify all resources held in a registry.
+- Paging based on `update` time from the end of a collection provides the best mechanism to watch for changing resources in the case that WebSocket subscriptions are not available.
 
-Paging through a collection for a second time, using the same cursors as previously SHOULD NOT result in new data appearing in the response payloads when using 'creation' ordering, provided the requested paging times are less than or equal to the maximum paging time held in the registry. However, note that as the registry is dynamic and resources could be updated or deleted a given cursor MAY return fewer results than it did previously. When using 'update' ordering and a query filter, new data MAY appear when cursors are used for a second time.
+Paging through a collection for a second time, using the same cursors as previously SHOULD NOT result in new data appearing in the response payloads when using `creation` ordering, provided the requested paging times are less than or equal to the maximum paging time held in the registry. However, note that as the registry is dynamic and resources could be updated or deleted a given cursor MAY return fewer results than it did previously. When using `update` ordering and a query filter, new data MAY appear when cursors are used for a second time.
 
 When query parameters which perform filtering are used at the same time as paging, the filters MUST be applied by the implementation before applying paging parameters to the resulting data set.
 
 A server MAY choose its own default value for paging limit (see Example 1).
 
-Where both 'since' and 'until' parameters are specified, the 'since' value takes precedence where a resulting data set is constrained by the server's value of 'limit' (see Example 5).
+Where both `since` and `until` parameters are specified, the `since` value takes precedence where a resulting data set is constrained by the server`s value of `limit` (see Example 5).
 
-Servers SHOULD include 'prev' and 'next' Link headers and MAY include 'first' and 'last' Link headers in all responses.
+Servers SHOULD include `prev` and `next` Link headers and MAY include `first` and `last` Link headers in all responses.
 
 ### Examples
 
-The following examples show pagination for a set of registered data. In order to avoid displaying full resource representations, the only data listed here is the 'update' timestamp associated with each registered record. The same procedures can be applied where 'creation' timestamps and the '?paging.order=create' parameter are used instead.
+The following examples show pagination for a set of registered data. In order to avoid displaying full resource representations, the only data listed here is the `update` timestamp associated with each registered record. The same procedures can be applied where `creation` timestamps and the `?paging.order=create` parameter are used instead.
 
-Where a paging limit is not specified in a request the server's default is used.
+Where a paging limit is not specified in a request the server`s default is used.
 
 **Sample Data: Registered Node Update Timestamps (Comma-Separated)**
 
@@ -47,7 +47,7 @@ Each of the above corresponds to the update timestamp of a corresponding Node, i
 
 Response payloads in the examples will show these values, but in a real implementation would be replaced by the corresponding JSON objects for the Nodes or other resources being queried.
 
-**Example 1: Initial /nodes Request**
+**Example 1: Initial `/nodes` Request**
 
 In this example there are no query parameters used in the request, but as the Query API supports pagination it returns a subset of the results with headers identifying how to page further into the collection.
 
@@ -88,8 +88,13 @@ Payload Resources
 ***Notes***
 
 - The data set returned when no query parameters are specified MUST be from the most recently updated (or created) resources in the collection, returned in descending order.
-- The X-Paging headers identify properties of the collection of data returned in the response. These parameters can be used to construct a URL which would return the same set of bounded data on consecutive requests (for example /x-nmos/query/v1.1/nodes?paging.since=0:10&paging.until=0:20).
-- The Link header identifies the 'next' and 'prev' cursors which an application MAY use to make its next requests. An implementation MAY also provide 'first' and 'last' cursors to identify the beginning and end of a collection if this can be addressed via a consistent URL.
+- The `X-Paging` headers identify properties of the collection of data returned in the response. These parameters can be used to construct a URL which would return the same set of bounded data on consecutive requests, for example:
+
+  ```
+  /x-nmos/query/v1.1/nodes?paging.since=0:10&paging.until=0:20
+  ```
+
+- The Link header identifies the `next` and `prev` cursors which an application MAY use to make its next requests. An implementation MAY also provide `first` and `last` cursors to identify the beginning and end of a collection if this can be addressed via a consistent URL.
 
 **Example 2: Request With Custom Limit**
 
@@ -238,13 +243,13 @@ Payload Resources
 
 ***Notes***
 
-- Whilst both 'since' and 'until' are specified, as this server example has a default paging limit of '10', the 'since' parameter  takes precedence. As a result of this the value of X-Paging-Until is lower than requested and a further request MUST be made to retrieve any remaining data.
+- Whilst both `since` and `until` are specified, as this server example has a default paging limit of `10`, the `since` parameter  takes precedence. As a result of this the value of X-Paging-Until is lower than requested and a further request MUST be made to retrieve any remaining data.
 
 ### Edge Cases
 
-When a client requests data which falls at the extreme ends of the stored data set it can be less clear what values SHOULD be returned in the 'X-Paging-Limit' and 'X-Paging-Since' headers. The following examples are intended to clarify these cases.
+When a client requests data which falls at the extreme ends of the stored data set it can be less clear what values SHOULD be returned in the `X-Paging-Limit` and `X-Paging-Since` headers. The following examples are intended to clarify these cases.
 
-Where a paging limit is not specified in a request the server's default is used.
+Where a paging limit is not specified in a request the server`s default is used.
 
 **Example 1: Client request occurs at the beginning of the data set**
 
@@ -254,7 +259,7 @@ Where a paging limit is not specified in a request the server's default is used.
 GET /x-nmos/query/v1.1/nodes?paging.until=0:20
 ```
 
-In this case, assume that there are stored records for '0:21' and '0:22' but no earlier.
+In this case, assume that there are stored records for `0:21` and `0:22` but no earlier.
 
 ***Response***
 
@@ -281,7 +286,7 @@ Payload Resources
 GET /x-nmos/query/v1.1/nodes?paging.since=0:20
 ```
 
-In this case, assume that there are stored records for '0:19' and '0:20' but no later.
+In this case, assume that there are stored records for `0:19` and `0:20` but no later.
 
 ***Response***
 
@@ -302,7 +307,7 @@ Payload Resources
 
 ***Notes:***
 
-- In this situation the client is expected to re-perform the same request (as specified in the 'next' cursor) until data is returned. If the client were to increment the value of 'since' requested it would be in danger of moving ahead of the current time and missing records.
+- In this situation the client is expected to re-perform the same request (as specified in the `next` cursor) until data is returned. If the client were to increment the value of `since` requested it would be in danger of moving ahead of the current time and missing records.
 
 **Example 3: Client request includes a query parameter resulting in a single result, but no paging parameters**
 
@@ -312,7 +317,7 @@ Payload Resources
 GET /x-nmos/query/v1.1/nodes?label=My%20Node
 ```
 
-In this case, assume that the most recently created or updated Node held in the registry has a paging value of '0:20' associated with it. Also assume that the Node with label 'My Node' has a paging time of '0:15'.
+In this case, assume that the most recently created or updated Node held in the registry has a paging value of `0:20` associated with it. Also assume that the Node with label `My Node` has a paging time of `0:15`.
 
 ***Response***
 
@@ -341,7 +346,7 @@ Payload Resources
 GET /x-nmos/query/v1.1/nodes?label=My%20Invalid%20Node
 ```
 
-In this case, assume that the most recently created or updated Node held in the registry has a paging value of '0:20' associated with it.
+In this case, assume that the most recently created or updated Node held in the registry has a paging value of `0:20` associated with it.
 
 ***Response***
 
@@ -362,7 +367,7 @@ Payload Resources
 
 ## Downgrade Queries
 
-Query APIs SHOULD support downgrade queries against their API resources where the 'downgrade' trait is specified in the RAML documentation. A 501 HTTP status code MUST be returned where a downgrade query is attempted against a Query API which does not implement it.
+Query APIs SHOULD support downgrade queries against their API resources where the `downgrade` trait is specified in the RAML documentation. A 501 HTTP status code MUST be returned where a downgrade query is attempted against a Query API which does not implement it.
 
 In order to streamline upgrades from one API version to another a Query API MAY sit in front of a registry which holds registered data matching multiple API versions' schemas. By default the Query API MUST only return data matching the API version specified in the request URL, however downgrade queries permit old-versioned responses to be provided to clients which are confident that they can handle any missing attributes between the specified API versions.
 
@@ -429,17 +434,26 @@ GET /x-nmos/query/v3.0/flows?query.downgrade=v1.0
 
 Query APIs SHOULD support basic queries against their API resources. A 501 HTTP status code MUST be returned where a basic query is attempted against a Query API which does not implement it.
 
-Basic queries make use of standard HTTP GET query parameters in the form '?key1=value1&key2=value2'. Keys MAY match any attribute which the API schemas indicate could be returned by a given resource.
+Basic queries make use of standard HTTP GET query parameters in the form `?key1=value1&key2=value2`. Keys MAY match any attribute which the API schemas indicate could be returned by a given resource.
 
-Any attribute which could be returned by a particular API resource SHOULD be available to use as a query parameter, however the RAML documentation only explicitly identifies core attributes under 'queryParameters'.
+Any attribute which could be returned by a particular API resource SHOULD be available to use as a query parameter, however the RAML documentation only explicitly identifies core attributes under `queryParameters`.
 
 If a query parameter is requested which does not match an attribute found in any resource, an empty result set MUST be returned.
 
 - Querying Within Objects
-  - Querying using attributes of objects is permitted via the use of a '.' separator. For example, the /receivers resource can be queried with '?subscription.sender_id=2683ad14-642f-459d-a169-ef91c76cec6b'.
+  - Querying using attributes of objects is permitted via the use of a `.` separator. For example, the `/receivers` resource can be queried with:
+  
+    ```
+    ?subscription.sender_id=2683ad14-642f-459d-a169-ef91c76cec6b
 
 - Querying Within Arrays
-  - Querying using attributes of objects held within arrays is permitted via the use of a '.' separator. For example, the /nodes resource can be queried with '?services.type=urn:x-manufacturer:service:tally'. More advanced queries within arrays might require use of the Resource Query Language 'in()' operator.
+  - Querying using attributes of objects held within arrays is permitted via the use of a `.` separator. For example, the `/nodes` resource can be queried with:
+  
+    ```
+    ?services.type=urn:x-manufacturer:service:tally
+    ```
+    
+    More advanced queries within arrays might require use of the Resource Query Language `in()` operator.
 
 ### Examples
 
@@ -453,7 +467,7 @@ GET /x-nmos/query/v1.0/senders?transport=urn:x-nmos:transport:rtp
 
 ***Response***
 
-- Returns all Sender objects which have an attribute 'transport' which exactly matches the string 'urn:x-nmos:transport:rtp'.
+- Returns all Sender objects which have an attribute `transport` which exactly matches the string `urn:x-nmos:transport:rtp`.
 
 **Example 2: Basic Query Using Two Parameters**
 
@@ -465,7 +479,7 @@ GET /x-nmos/query/v1.0/sources?format=urn:x-nmos:format:video&device_id=9126cc2f
 
 ***Response***
 
-- Returns all Source objects which have an attribute of 'format' which exactly matches 'urn:x-nmos:format:video' AND a 'device_id' attribute which exactly matches '9126cc2f-4c26-4c9b-a6cd-93c4381c9be5'.
+- Returns all Source objects which have an attribute of `format` which exactly matches `urn:x-nmos:format:video` AND a `device_id` attribute which exactly matches `9126cc2f-4c26-4c9b-a6cd-93c4381c9be5`.
 
 **Example 3: Querying Within Objects**
 
@@ -477,7 +491,7 @@ GET /x-nmos/query/v1.0/flows?tags.studio=HQ1
 
 ***Response***
 
-- Returns all Flows which have a 'tags' attribute with a key of 'studio'. The value of 'tags.studio' (which is an array in this case, see Flow schema) MUST contain 'HQ1' as one of its entries.
+- Returns all Flows which have a `tags` attribute with a key of `studio`. The value of `tags.studio` (which is an array in this case, see Flow schema) MUST contain `HQ1` as one of its entries.
 
 **Example 4: Querying Within Arrays**
 
@@ -489,7 +503,7 @@ GET /x-nmos/query/v1.0/nodes?services.type=urn:x-manufacturer:service:myservice
 
 ***Response***
 
-- The schema defines a Node's 'services' as an array of objects, where 'type' is a key in these inner objects. As a result, this query returns all Nodes where one of these service objects has a 'type' of 'urn:x-manufacturer:service:myservice'.
+- The schema defines a Node's `services` as an array of objects, where `type` is a key in these inner objects. As a result, this query returns all Nodes where one of these service objects has a `type` of `urn:x-manufacturer:service:myservice`.
 
 ### Invalid Examples
 
@@ -507,11 +521,11 @@ GET /x-nmos/query/v1.0/flows?tags.location=Salford&tags.location=London
 
 ## Advanced (RQL) Queries (OPTIONAL)
 
-Query APIs MAY support Resource Query Language (RQL, <https://github.com/persvr/rql/>) queries against their API resources where the 'rql' trait is specified in the RAML documentation. A 501 HTTP status code MUST be returned where a RAML query is attempted using RQL functions or operators which are not supported by a Query API.
+Query APIs MAY support Resource Query Language (RQL, <https://github.com/persvr/rql/>) queries against their API resources where the `rql` trait is specified in the RAML documentation. A 501 HTTP status code MUST be returned where a RAML query is attempted using RQL functions or operators which are not supported by a Query API.
 
-RQL SHOULD be formatted in the normalised form as opposed to using FIQL syntax, and passed via the query string using '?query.rql=...'.
+RQL SHOULD be formatted in the normalised form as opposed to using FIQL syntax, and passed via the query string using `?query.rql=...`.
 
-Querying within objects and arrays SHOULD be performed as in the Basic Queries case by using the '.' separator.
+Querying within objects and arrays SHOULD be performed as in the Basic Queries case by using the `.` separator.
 
 When an RQL query is specified, the Basic Queries format MAY be ignored in order to simplify implementation.
 
@@ -541,7 +555,7 @@ GET /x-nmos/query/v1.1/senders?query.rql=eq(transport,urn%3Ax-nmos%3Atransport%3
 
 ***Response***
 
-- Returns all Sender objects which have an attribute 'transport' which exactly matches the string 'urn:x-nmos:transport:rtp'. This response matches that of 'Example 1' in basic querying.
+- Returns all Sender objects which have an attribute `transport` which exactly matches the string `urn:x-nmos:transport:rtp`. This response matches that of Example 1 in basic querying.
 
 **Example 2: Advanced Query**
 
@@ -553,13 +567,13 @@ GET /x-nmos/query/v1.1/sources?query.rql=and(eq(format,urn%3Ax-nmos%3Aformat%3Av
 
 ***Response***
 
-- Returns all Sources which have a 'format' attribute equal to 'urn:x-nmos:format:video' and a 'tags' attribute with a key of 'location', which has values of 'Salford' or 'London'.
+- Returns all Sources which have a `format` attribute equal to `urn:x-nmos:format:video` and a `tags` attribute with a key of `location`, which has values of `Salford` or `London`.
 
 ## Ancestry Queries (OPTIONAL)
 
-Query APIs MAY support Source and Flow ancestry queries against their API resources where the 'ancestry' trait is specified in the RAML documentation. A 501 HTTP status code MUST be returned where an ancestry query is attempted against a Query API which does not implement it.
+Query APIs MAY support Source and Flow ancestry queries against their API resources where the `ancestry` trait is specified in the RAML documentation. A 501 HTTP status code MUST be returned where an ancestry query is attempted against a Query API which does not implement it.
 
-Sources and Flows list their 'parents' in an array. A Query API implementing ancestry tracking MAY be queried using '?query.ancestry_...' parameters in order to identify parents or children of a given Source or Flow.
+Sources and Flows list their `parents` in an array. A Query API implementing ancestry tracking MAY be queried using `?query.ancestry_...` parameters in order to identify parents or children of a given Source or Flow.
 
 ### Examples
 
@@ -581,13 +595,13 @@ X-Ancestry-Generations: 4
 
 Payload
 
-- Returns Sources which list an ID of 'c1398579-15bc-468e-91ec-df5bbefe1cd3' in their 'parents' attribute array. These are the first generation ancestors.
-- For each first generation ancestor found, the ID of these Sources is used to look up the next generation in the 'parents' arrays of further Sources.
-- This process continues up to the generation limit returned in the X-Ancestry-Generations header. The server MAY refuse to honour a requested ''?query.ancestry_generations' value using a 400 error code if it is deemed to be too resource intensive.
+- Returns Sources which list an ID of `c1398579-15bc-468e-91ec-df5bbefe1cd3` in their `parents` attribute array. These are the first generation ancestors.
+- For each first generation ancestor found, the ID of these Sources is used to look up the next generation in the `parents` arrays of further Sources.
+- This process continues up to the generation limit returned in the X-Ancestry-Generations header. The server MAY refuse to honour a requested `?query.ancestry_generations` value using a 400 error code if it is deemed to be too resource intensive.
 
 ***Notes***
 
-- Responses SHOULD NOT include the Source with ID specified in the 'ancestry_id' parameter.
+- Responses SHOULD NOT include the Source with ID specified in the `ancestry_id` parameter.
 
 **Example 2: Parents Of A Flow**
 
@@ -607,10 +621,10 @@ X-Ancestry-Generations: 2
 
 Payload
 
-- Returns Flows which are listed in the 'parents' array of the Flow identified by the ID 'ad14888a-3a98-444c-8aa8-4d87b77cbaa1'. These are the first generation parents.
-- For each first generation parent found, their 'parents' array is used to identify the next generation of parents to be returned.
-- This process continues up to the generation limit returned in the X-Ancestry-Generations header (in this case limited to 2 by a query parameter). The server MAY refuse to honour a requested ''?query.ancestry_generations' value using a 400 error code if it is deemed to be too resource intensive.
+- Returns Flows which are listed in the `parents` array of the Flow identified by the ID `ad14888a-3a98-444c-8aa8-4d87b77cbaa1`. These are the first generation parents.
+- For each first generation parent found, their `parents` array is used to identify the next generation of parents to be returned.
+- This process continues up to the generation limit returned in the X-Ancestry-Generations header (in this case limited to 2 by a query parameter). The server MAY refuse to honour a requested `?query.ancestry_generations` value using a 400 error code if it is deemed to be too resource intensive.
 
 ***Notes***
 
-- Responses SHOULD NOT include the Flow with ID specified in the 'ancestry_id' parameter.
+- Responses SHOULD NOT include the Flow with ID specified in the `ancestry_id` parameter.

--- a/docs/2.5. APIs - Query Parameters.md
+++ b/docs/2.5. APIs - Query Parameters.md
@@ -445,6 +445,7 @@ If a query parameter is requested which does not match an attribute found in any
   
     ```
     ?subscription.sender_id=2683ad14-642f-459d-a169-ef91c76cec6b
+    ```
 
 - Querying Within Arrays
   - Querying using attributes of objects held within arrays is permitted via the use of a `.` separator. For example, the `/nodes` resource can be queried with:

--- a/docs/2.5. APIs - Query Parameters.md
+++ b/docs/2.5. APIs - Query Parameters.md
@@ -2,7 +2,7 @@
 
 _(c) AMWA 2016, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
-The Query API supports a range of query string parameters which MAY be used as part of GET requests, or within WebSocket subscriptions.
+The Query API supports a range of query string parameters which MAY be used as part of `GET` requests, or within WebSocket subscriptions.
 
 The following document describes the expected usage and behaviour of these query parameters alongside the RAML specification in order to aid implementers. A description of each individual query parameter is included within the RAML.
 
@@ -434,7 +434,7 @@ GET /x-nmos/query/v3.0/flows?query.downgrade=v1.0
 
 Query APIs SHOULD support basic queries against their API resources. A 501 HTTP status code MUST be returned where a basic query is attempted against a Query API which does not implement it.
 
-Basic queries make use of standard HTTP GET query parameters in the form `?key1=value1&key2=value2`. Keys MAY match any attribute which the API schemas indicate could be returned by a given resource.
+Basic queries make use of standard HTTP `GET` query parameters in the form `?key1=value1&key2=value2`. Keys MAY match any attribute which the API schemas indicate could be returned by a given resource.
 
 Any attribute which could be returned by a particular API resource SHOULD be available to use as a query parameter, however the RAML documentation only explicitly identifies core attributes under `queryParameters`.
 

--- a/docs/2.5. APIs - Query Parameters.md
+++ b/docs/2.5. APIs - Query Parameters.md
@@ -88,7 +88,7 @@ Payload Resources
 ***Notes***
 
 - The data set returned when no query parameters are specified MUST be from the most recently updated (or created) resources in the collection, returned in descending order.
-- The `X-Paging` headers identify properties of the collection of data returned in the response. These parameters can be used to construct a URL which would return the same set of bounded data on consecutive requests, for example:
+- The `X-Paging-` headers identify properties of the collection of data returned in the response. These parameters can be used to construct a URL which would return the same set of bounded data on consecutive requests, for example:
 
   ```
   /x-nmos/query/v1.1/nodes?paging.since=0:10&paging.until=0:20
@@ -243,7 +243,7 @@ Payload Resources
 
 ***Notes***
 
-- Whilst both `since` and `until` are specified, as this server example has a default paging limit of `10`, the `since` parameter  takes precedence. As a result of this the value of X-Paging-Until is lower than requested and a further request MUST be made to retrieve any remaining data.
+- Whilst both `since` and `until` are specified, as this server example has a default paging limit of `10`, the `since` parameter  takes precedence. As a result of this the value of `X-Paging-Until` is lower than requested and a further request MUST be made to retrieve any remaining data.
 
 ### Edge Cases
 

--- a/docs/2.5. APIs - Query Parameters.md
+++ b/docs/2.5. APIs - Query Parameters.md
@@ -27,7 +27,7 @@ When query parameters which perform filtering are used at the same time as pagin
 
 A server MAY choose its own default value for paging limit (see Example 1).
 
-Where both `since` and `until` parameters are specified, the `since` value takes precedence where a resulting data set is constrained by the server`s value of `limit` (see Example 5).
+Where both `since` and `until` parameters are specified, the `since` value takes precedence where a resulting data set is constrained by the server's value of `limit` (see Example 5).
 
 Servers SHOULD include `prev` and `next` Link headers and MAY include `first` and `last` Link headers in all responses.
 
@@ -35,7 +35,7 @@ Servers SHOULD include `prev` and `next` Link headers and MAY include `first` an
 
 The following examples show pagination for a set of registered data. In order to avoid displaying full resource representations, the only data listed here is the `update` timestamp associated with each registered record. The same procedures can be applied where `creation` timestamps and the `?paging.order=create` parameter are used instead.
 
-Where a paging limit is not specified in a request the server`s default is used.
+Where a paging limit is not specified in a request the server's default is used.
 
 **Sample Data: Registered Node Update Timestamps (Comma-Separated)**
 

--- a/docs/2.5. APIs - Query Parameters.md
+++ b/docs/2.5. APIs - Query Parameters.md
@@ -33,7 +33,7 @@ Servers SHOULD include `prev` and `next` Link headers and MAY include `first` an
 
 ### Examples
 
-The following examples show pagination for a set of registered data. In order to avoid displaying full resource representations, the only data listed here is the `update` timestamp associated with each registered record. The same procedures can be applied where `creation` timestamps and the `?paging.order=create` parameter are used instead.
+The following examples show pagination for a set of registered data. In order to avoid displaying full resource representations, the only data listed here is the `update` timestamp associated with each registered record. The same procedures can be applied where `creation` timestamps and the `paging.order=create` query parameter are used instead.
 
 Where a paging limit is not specified in a request the server's default is used.
 
@@ -131,7 +131,7 @@ Payload Resources
 
 ***Notes***
 
-- In this case the server has accepted the client's paging size limit request. If the client had requested a page size which the server was unable to honour, the actual page size used would be returned in X-Paging-Limit.
+- In this case the server has accepted the client's paging size limit request. If the client had requested a page size which the server was unable to honour, the actual page size used would be returned in `X-Paging-Limit`.
 
 **Example 3: Request With Since Parameter**
 
@@ -524,7 +524,7 @@ GET /x-nmos/query/v1.0/flows?tags.location=Salford&tags.location=London
 
 Query APIs MAY support Resource Query Language (RQL, <https://github.com/persvr/rql/>) queries against their API resources where the `rql` trait is specified in the RAML documentation. A 501 (Not Implemented) HTTP status code MUST be returned where an RQL query is attempted using RQL functions or operators which are not supported by a Query API.
 
-RQL SHOULD be formatted in the normalised form as opposed to using FIQL syntax, and passed via the query string using `?query.rql=...`.
+RQL SHOULD be formatted in the normalised form as opposed to using FIQL syntax, and passed via the query string using a `query.rql=...` query parameter.
 
 Querying within objects and arrays SHOULD be performed as in the Basic Queries case by using the `.` separator.
 
@@ -574,7 +574,7 @@ GET /x-nmos/query/v1.1/sources?query.rql=and(eq(format,urn%3Ax-nmos%3Aformat%3Av
 
 Query APIs MAY support Source and Flow ancestry queries against their API resources where the `ancestry` trait is specified in the RAML documentation. A 501 (Not Implemented) HTTP status code MUST be returned where an ancestry query is attempted against a Query API which does not implement it.
 
-Sources and Flows list their `parents` in an array. A Query API implementing ancestry tracking MAY be queried using `?query.ancestry_...` parameters in order to identify parents or children of a given Source or Flow.
+Sources and Flows list their `parents` in an array. A Query API implementing ancestry tracking MAY be queried using `query.ancestry_...` query parameters in order to identify parents or children of a given Source or Flow.
 
 ### Examples
 
@@ -598,7 +598,7 @@ Payload
 
 - Returns Sources which list an ID of `c1398579-15bc-468e-91ec-df5bbefe1cd3` in their `parents` attribute array. These are the first generation ancestors.
 - For each first generation ancestor found, the ID of these Sources is used to look up the next generation in the `parents` arrays of further Sources.
-- This process continues up to the generation limit returned in the X-Ancestry-Generations header. The server MAY refuse to honour a requested `?query.ancestry_generations` value using a 400 (Bad Request) error code if it is deemed to be too resource intensive.
+- This process continues up to the generation limit returned in the `X-Ancestry-Generations` header. The server MAY refuse to honour a requested `query.ancestry_generations` value using a 400 (Bad Request) error code if it is deemed to be too resource intensive.
 
 ***Notes***
 
@@ -624,7 +624,7 @@ Payload
 
 - Returns Flows which are listed in the `parents` array of the Flow identified by the ID `ad14888a-3a98-444c-8aa8-4d87b77cbaa1`. These are the first generation parents.
 - For each first generation parent found, their `parents` array is used to identify the next generation of parents to be returned.
-- This process continues up to the generation limit returned in the X-Ancestry-Generations header (in this case limited to 2 by a query parameter). The server MAY refuse to honour a requested `?query.ancestry_generations` value using a 400 (Bad Request) error code if it is deemed to be too resource intensive.
+- This process continues up to the generation limit returned in the `X-Ancestry-Generations` header (in this case limited to 2 by a query parameter). The server MAY refuse to honour a requested `query.ancestry_generations` value using a 400 (Bad Request) error code if it is deemed to be too resource intensive.
 
 ***Notes***
 

--- a/docs/2.5. APIs - Query Parameters.md
+++ b/docs/2.5. APIs - Query Parameters.md
@@ -8,7 +8,7 @@ The following document describes the expected usage and behaviour of these query
 
 ## Pagination
 
-Query APIs SHOULD support pagination of their API resources where the `paged` trait is specified in the RAML documentation. A 501 HTTP status code MUST be returned where pagination is attempted against a Query API which does not implement it. Pagination is not used by WebSocket subscriptions.
+Query APIs SHOULD support pagination of their API resources where the `paged` trait is specified in the RAML documentation. A 501 (Not Implemented) HTTP status code MUST be returned where pagination is attempted against a Query API which does not implement it. Pagination is not used by WebSocket subscriptions.
 
 Query API clients MUST detect whether pagination is being used by examining the HTTP response headers for `X-Paging-Limit` which MUST be returned in all cases where pagination is in use.
 
@@ -367,7 +367,7 @@ Payload Resources
 
 ## Downgrade Queries
 
-Query APIs SHOULD support downgrade queries against their API resources where the `downgrade` trait is specified in the RAML documentation. A 501 HTTP status code MUST be returned where a downgrade query is attempted against a Query API which does not implement it.
+Query APIs SHOULD support downgrade queries against their API resources where the `downgrade` trait is specified in the RAML documentation. A 501 (Not Implemented) HTTP status code MUST be returned where a downgrade query is attempted against a Query API which does not implement it.
 
 In order to streamline upgrades from one API version to another a Query API MAY sit in front of a registry which holds registered data matching multiple API versions' schemas. By default the Query API MUST only return data matching the API version specified in the request URL, however downgrade queries permit old-versioned responses to be provided to clients which are confident that they can handle any missing attributes between the specified API versions.
 
@@ -428,11 +428,11 @@ GET /x-nmos/query/v3.0/flows?query.downgrade=v1.0
 
 ***Response***
 
-- Returns an HTTP 400 error code as downgrade queries MUST NOT be performed between major API versions.
+- Returns an HTTP 400 (Bad Request) error code as downgrade queries MUST NOT be performed between major API versions.
 
 ## Basic Queries
 
-Query APIs SHOULD support basic queries against their API resources. A 501 HTTP status code MUST be returned where a basic query is attempted against a Query API which does not implement it.
+Query APIs SHOULD support basic queries against their API resources. A 501 (Not Implemented) HTTP status code MUST be returned where a basic query is attempted against a Query API which does not implement it.
 
 Basic queries make use of standard HTTP `GET` query parameters in the form `?key1=value1&key2=value2`. Keys MAY match any attribute which the API schemas indicate could be returned by a given resource.
 
@@ -522,7 +522,7 @@ GET /x-nmos/query/v1.0/flows?tags.location=Salford&tags.location=London
 
 ## Advanced (RQL) Queries (OPTIONAL)
 
-Query APIs MAY support Resource Query Language (RQL, <https://github.com/persvr/rql/>) queries against their API resources where the `rql` trait is specified in the RAML documentation. A 501 HTTP status code MUST be returned where a RAML query is attempted using RQL functions or operators which are not supported by a Query API.
+Query APIs MAY support Resource Query Language (RQL, <https://github.com/persvr/rql/>) queries against their API resources where the `rql` trait is specified in the RAML documentation. A 501 (Not Implemented) HTTP status code MUST be returned where an RQL query is attempted using RQL functions or operators which are not supported by a Query API.
 
 RQL SHOULD be formatted in the normalised form as opposed to using FIQL syntax, and passed via the query string using `?query.rql=...`.
 
@@ -530,7 +530,7 @@ Querying within objects and arrays SHOULD be performed as in the Basic Queries c
 
 When an RQL query is specified, the Basic Queries format MAY be ignored in order to simplify implementation.
 
-Note that as RQL permits the definition of very complex queries, the server MAY return a 400 error code to indicate that it is refusing to action the client's request due to the query's complexity.
+Note that as RQL permits the definition of very complex queries, the server MAY return a 400 (Bad Request) error code to indicate that it is refusing to action the client's request due to the query's complexity.
 
 ### Constraints
 
@@ -572,7 +572,7 @@ GET /x-nmos/query/v1.1/sources?query.rql=and(eq(format,urn%3Ax-nmos%3Aformat%3Av
 
 ## Ancestry Queries (OPTIONAL)
 
-Query APIs MAY support Source and Flow ancestry queries against their API resources where the `ancestry` trait is specified in the RAML documentation. A 501 HTTP status code MUST be returned where an ancestry query is attempted against a Query API which does not implement it.
+Query APIs MAY support Source and Flow ancestry queries against their API resources where the `ancestry` trait is specified in the RAML documentation. A 501 (Not Implemented) HTTP status code MUST be returned where an ancestry query is attempted against a Query API which does not implement it.
 
 Sources and Flows list their `parents` in an array. A Query API implementing ancestry tracking MAY be queried using `?query.ancestry_...` parameters in order to identify parents or children of a given Source or Flow.
 
@@ -598,7 +598,7 @@ Payload
 
 - Returns Sources which list an ID of `c1398579-15bc-468e-91ec-df5bbefe1cd3` in their `parents` attribute array. These are the first generation ancestors.
 - For each first generation ancestor found, the ID of these Sources is used to look up the next generation in the `parents` arrays of further Sources.
-- This process continues up to the generation limit returned in the X-Ancestry-Generations header. The server MAY refuse to honour a requested `?query.ancestry_generations` value using a 400 error code if it is deemed to be too resource intensive.
+- This process continues up to the generation limit returned in the X-Ancestry-Generations header. The server MAY refuse to honour a requested `?query.ancestry_generations` value using a 400 (Bad Request) error code if it is deemed to be too resource intensive.
 
 ***Notes***
 
@@ -624,7 +624,7 @@ Payload
 
 - Returns Flows which are listed in the `parents` array of the Flow identified by the ID `ad14888a-3a98-444c-8aa8-4d87b77cbaa1`. These are the first generation parents.
 - For each first generation parent found, their `parents` array is used to identify the next generation of parents to be returned.
-- This process continues up to the generation limit returned in the X-Ancestry-Generations header (in this case limited to 2 by a query parameter). The server MAY refuse to honour a requested `?query.ancestry_generations` value using a 400 error code if it is deemed to be too resource intensive.
+- This process continues up to the generation limit returned in the X-Ancestry-Generations header (in this case limited to 2 by a query parameter). The server MAY refuse to honour a requested `?query.ancestry_generations` value using a 400 (Bad Request) error code if it is deemed to be too resource intensive.
 
 ***Notes***
 

--- a/docs/3.0. Discovery.md
+++ b/docs/3.0. Discovery.md
@@ -24,7 +24,7 @@ When performing a DNS-SD browse, clients SHOULD proceed as follows:
 
 1. Identify whether the client has been configured with DNS server addresses and a default search domain either manually or automatically via DHCP.
 2. If such configuration exists and the discovery mechanism is not explicitly set to mDNS, perform a unicast DNS browse for services of the appropriate type via the search domain.
-3. If no unicast responses are received and the discovery mechanism is not explicitly set to unicast DNS, perform a multicast DNS browse for services of the appropriate type in the  `.local ` domain.
+3. If no unicast responses are received and the discovery mechanism is not explicitly set to unicast DNS, perform a multicast DNS browse for services of the appropriate type in the `.local` domain.
 
    - Note that if a unicast response is received, multicast browsing SHOULD NOT be performed even if the unicast-discovered API is unresponsive.
 

--- a/docs/3.0. Discovery.md
+++ b/docs/3.0. Discovery.md
@@ -6,13 +6,13 @@ NMOS Discovery makes use of the DNS Service Discovery protocol as described in [
 
 Three DNS-SD service types are defined by this specification:
 
-- **_nmos-node._tcp:** A logical host which advertises a Node API.
-- **_nmos-register._tcp** A logical host which advertises a Registration API.
-- **_nmos-query._tcp** A logical host which advertises a Query API.
+- **`_nmos-node._tcp`**: A logical host which advertises a Node API.
+- **`_nmos-register._tcp`**: A logical host which advertises a Registration API.
+- **`_nmos-query._tcp`**: A logical host which advertises a Query API.
 
 The following is an additional DNS-SD service type REQUIRED for implementations supporting older versions of the Registration API (v1.2 and below):
 
-- **_nmos-registration._tcp** A logical host which advertises a Registration API.
+- **`_nmos-registration._tcp`**: A logical host which advertises a Registration API.
 
 Advertisements of the above types are accompanied by DNS TXT records as specified within the following specification pages.
 
@@ -24,7 +24,7 @@ When performing a DNS-SD browse, clients SHOULD proceed as follows:
 
 1. Identify whether the client has been configured with DNS server addresses and a default search domain either manually or automatically via DHCP.
 2. If such configuration exists and the discovery mechanism is not explicitly set to mDNS, perform a unicast DNS browse for services of the appropriate type via the search domain.
-3. If no unicast responses are received and the discovery mechanism is not explicitly set to unicast DNS, perform a multicast DNS browse for services of the appropriate type in the '.local' domain.
+3. If no unicast responses are received and the discovery mechanism is not explicitly set to unicast DNS, perform a multicast DNS browse for services of the appropriate type in the  `.local ` domain.
 
    - Note that if a unicast response is received, multicast browsing SHOULD NOT be performed even if the unicast-discovered API is unresponsive.
 

--- a/docs/3.1. Discovery - Registered Operation.md
+++ b/docs/3.1. Discovery - Registered Operation.md
@@ -45,7 +45,7 @@ Values 0 to 99 correspond to an active NMOS Registration API (zero being the hig
 
    - Nodes which support v1.2 and earlier versions MUST additionally browse for the deprecated service type `_nmos-registration._tcp`.
 
-3. Given multiple returned Registration APIs, the Node orders these based on their advertised priority (TXT pri), filtering out any APIs which do not support the desired API version, protocol and authorization mode (TXT api_ver, api_proto and api_auth).
+3. Given multiple returned Registration APIs, the Node orders these based on their advertised priority (TXT `pri`), filtering out any APIs which do not support the desired API version, protocol and authorization mode (TXT `api_ver`, `api_proto` and `api_auth`).
 
    - Where a Node supports multiple API versions simultaneously, see the [Upgrade Path](6.0.%20Upgrade%20Path.md) for additional requirements in filtering the discovered API list.
 
@@ -81,7 +81,7 @@ The DNS-SD advertisement MUST be accompanied by a TXT record of name `api_ver`. 
 
 The DNS-SD advertisement MUST be accompanied by a TXT record of name `api_auth` with a value of either `true` or `false` dependent on whether authorization is needed in order to interact with the Query API or not.
 
-**pri**
+#### `pri`
 
 The DNS-SD advertisement MUST include a TXT record with key `pri` and an integer value. Servers MAY additionally represent a matching priority via the DNS-SD SRV record `priority` and `weight` as defined in RFC 2782. The TXT record SHOULD be used in favour to the SRV priority and weight where these values differ in order to overcome issues in the Bonjour and Avahi implementations.
 Values 0 to 99 correspond to an active NMOS Query API (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system.
@@ -92,7 +92,7 @@ Values 0 to 99 correspond to an active NMOS Query API (zero being the highest pr
 
 2. Node scans for an active Query API on the network using unicast and/or multicast DNS service discovery (type `_nmos-query._tcp`) as described in the [Discovery](3.0.%20Discovery.md#unicast-vs-multicast-dns-sd) document.
 
-3. Given multiple returned Query APIs, the Node orders these based on their advertised priority (TXT pri), filtering out any APIs which do not support the desired API version, protocol and authorization mode (TXT api_ver, api_proto and api_auth).
+3. Given multiple returned Query APIs, the Node orders these based on their advertised priority (TXT `pri`), filtering out any APIs which do not support the desired API version, protocol and authorization mode (TXT `api_ver`, `api_proto` and `api_auth`).
 
    - Where a Node supports multiple API versions simultaneously, see the [Upgrade Path](6.0.%20Upgrade%20Path.md) for additional requirements in filtering the discovered API list.
 

--- a/docs/3.1. Discovery - Registered Operation.md
+++ b/docs/3.1. Discovery - Registered Operation.md
@@ -8,11 +8,11 @@ This document describes usage of NMOS APIs for discovery in cases where where a 
 
 ### DNS-SD Advertisement
 
-The preferred method of Registration API advertisement is via unicast DNS-SD advertisement of the type  `_nmos-register._tcp`. Registration APIs MUST additionally be capable of producing an mDNS advertisement. This MAY be disabled via a user-configurable method.
+The preferred method of Registration API advertisement is via unicast DNS-SD advertisement of the type `_nmos-register._tcp`. Registration APIs MUST additionally be capable of producing an mDNS advertisement. This MAY be disabled via a user-configurable method.
 
 Registration APIs supporting versions `v1.2` and below MUST additionally be capable of producing an mDNS advertisement of type `_nmos-registration._tcp`. This MAY be disabled via a user-configurable method.
 
-*Note: RFC6763 Section 7.2 specifies that the maximum service name length for an mDNS advertisement is 16 characters when including the leading underscore, but "`_nmos-registration`" is 18 characters.*
+*Note: [RFC 6763 Section 7.2](https://tools.ietf.org/html/rfc6763#section-7.2) specifies that the maximum service name length for an mDNS advertisement is 16 characters when including the leading underscore, but "`_nmos-registration`" is 18 characters.*
 
 The IP address and port of the Registration API MUST be identified via the DNS-SD advertisement, with the full HTTP path then being resolved via the standard NMOS API path documentation.
 
@@ -34,7 +34,7 @@ The DNS-SD advertisement MUST be accompanied by a TXT record of name `api_auth` 
 
 #### `pri`
 
-The DNS-SD advertisement MUST include a TXT record with key `pri` and an integer value. Servers MAY additionally represent a matching priority via the DNS-SD SRV record `priority` and `weight` as defined in RFC 2782. The TXT record SHOULD be used in favour to the SRV priority and weight where these values differ in order to overcome issues in the Bonjour and Avahi implementations.
+The DNS-SD advertisement MUST include a TXT record with key `pri` and an integer value. Servers MAY additionally represent a matching priority via the DNS-SD SRV record `priority` and `weight` (see RFC 2782). The TXT record SHOULD be used in favour to the SRV priority and weight where these values differ in order to overcome issues in the Bonjour and Avahi implementations.
 Values 0 to 99 correspond to an active NMOS Registration API (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system.
 
 ### Client Interaction Procedure
@@ -69,21 +69,21 @@ Multiple DNS-SD advertisements for the same API are permitted where the API is e
 
 ### DNS-SD TXT Records
 
-**api_proto**
+#### `api_proto`
 
 The DNS-SD advertisement MUST be accompanied by a TXT record of name `api_proto` with a value of either `http` or `https` dependent on the protocol in use by the Query API web server.
 
-**api_ver**
+#### `api_ver`
 
 The DNS-SD advertisement MUST be accompanied by a TXT record of name `api_ver`. The value of this TXT record is a comma separated list of API versions supported by the server. For example: `v1.0,v1.1,v2.0`. There SHOULD be no whitespace between commas, and versions SHOULD be listed in ascending order.
 
-**api_auth**
+#### `api_auth`
 
 The DNS-SD advertisement MUST be accompanied by a TXT record of name `api_auth` with a value of either `true` or `false` dependent on whether authorization is needed in order to interact with the Query API or not.
 
 #### `pri`
 
-The DNS-SD advertisement MUST include a TXT record with key `pri` and an integer value. Servers MAY additionally represent a matching priority via the DNS-SD SRV record `priority` and `weight` as defined in RFC 2782. The TXT record SHOULD be used in favour to the SRV priority and weight where these values differ in order to overcome issues in the Bonjour and Avahi implementations.
+The DNS-SD advertisement MUST include a TXT record with key `pri` and an integer value. Servers MAY additionally represent a matching priority via the DNS-SD SRV record `priority` and `weight` (see RFC 2782). The TXT record SHOULD be used in favour to the SRV priority and weight where these values differ in order to overcome issues in the Bonjour and Avahi implementations.
 Values 0 to 99 correspond to an active NMOS Query API (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system.
 
 ### Client Interaction Procedure

--- a/docs/3.1. Discovery - Registered Operation.md
+++ b/docs/3.1. Discovery - Registered Operation.md
@@ -8,11 +8,11 @@ This document describes usage of NMOS APIs for discovery in cases where where a 
 
 ### DNS-SD Advertisement
 
-The preferred method of Registration API advertisement is via unicast DNS-SD advertisement of the type \_nmos-register.\_tcp. Registration APIs MUST additionally be capable of producing an mDNS advertisement. This MAY be disabled via a user-configurable method.
+The preferred method of Registration API advertisement is via unicast DNS-SD advertisement of the type  `_nmos-register._tcp`. Registration APIs MUST additionally be capable of producing an mDNS advertisement. This MAY be disabled via a user-configurable method.
 
-Registration APIs supporting versions 'v1.2' and below MUST additionally be capable of producing an mDNS advertisement of type \_nmos-registration.\_tcp. This MAY be disabled via a user-configurable method.
+Registration APIs supporting versions `v1.2` and below MUST additionally be capable of producing an mDNS advertisement of type `_nmos-registration._tcp`. This MAY be disabled via a user-configurable method.
 
-*Note: RFC6763 Section 7.2 specifies that the maximum service name length for an mDNS advertisement is 16 characters when including the leading underscore, but "_nmos-registration" is 18 characters.*
+*Note: RFC6763 Section 7.2 specifies that the maximum service name length for an mDNS advertisement is 16 characters when including the leading underscore, but "`_nmos-registration`" is 18 characters.*
 
 The IP address and port of the Registration API MUST be identified via the DNS-SD advertisement, with the full HTTP path then being resolved via the standard NMOS API path documentation.
 
@@ -20,30 +20,30 @@ Multiple DNS-SD advertisements for the same API are permitted where the API is e
 
 ### DNS-SD TXT Records
 
-### api\_proto
+#### `api_proto`
 
-The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_proto' with a value of either 'http' or 'https' dependent on the protocol in use by the Registration API web server.
+The DNS-SD advertisement MUST be accompanied by a TXT record of name `api_proto` with a value of either `http` or `https` dependent on the protocol in use by the Registration API web server.
 
-### api\_ver
+#### `api_ver`
 
-The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_ver'. The value of this TXT record is a comma separated list of API versions supported by the server. For example: 'v1.0,v1.1,v2.0'. There SHOULD be no whitespace between commas, and versions SHOULD be listed in ascending order.
+The DNS-SD advertisement MUST be accompanied by a TXT record of name `api_ver`. The value of this TXT record is a comma separated list of API versions supported by the server. For example: `v1.0,v1.1,v2.0`. There SHOULD be no whitespace between commas, and versions SHOULD be listed in ascending order.
 
-### api\_auth
+#### `api_auth`
 
-The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_auth' with a value of either 'true' or 'false' dependent on whether authorization is needed for Registration API requests.
+The DNS-SD advertisement MUST be accompanied by a TXT record of name `api_auth` with a value of either `true` or `false` dependent on whether authorization is needed for Registration API requests.
 
-### pri
+#### `pri`
 
-The DNS-SD advertisement MUST include a TXT record with key 'pri' and an integer value. Servers MAY additionally represent a matching priority via the DNS-SD SRV record 'priority' and 'weight' as defined in RFC 2782. The TXT record SHOULD be used in favour to the SRV priority and weight where these values differ in order to overcome issues in the Bonjour and Avahi implementations.
+The DNS-SD advertisement MUST include a TXT record with key `pri` and an integer value. Servers MAY additionally represent a matching priority via the DNS-SD SRV record `priority` and `weight` as defined in RFC 2782. The TXT record SHOULD be used in favour to the SRV priority and weight where these values differ in order to overcome issues in the Bonjour and Avahi implementations.
 Values 0 to 99 correspond to an active NMOS Registration API (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system.
 
 ### Client Interaction Procedure
 
 1. Node comes online
 
-2. Node scans for an active Registration API on the network using unicast and/or multicast DNS service discovery (type '\_nmos-register.\_tcp') as described in the [Discovery](3.0.%20Discovery.md#unicast-vs-multicast-dns-sd) document.
+2. Node scans for an active Registration API on the network using unicast and/or multicast DNS service discovery (type `_nmos-register._tcp`) as described in the [Discovery](3.0.%20Discovery.md#unicast-vs-multicast-dns-sd) document.
 
-   - Nodes which support v1.2 and earlier versions MUST additionally browse for the deprecated service type '\_nmos-registration.\_tcp'.
+   - Nodes which support v1.2 and earlier versions MUST additionally browse for the deprecated service type `_nmos-registration._tcp`.
 
 3. Given multiple returned Registration APIs, the Node orders these based on their advertised priority (TXT pri), filtering out any APIs which do not support the desired API version, protocol and authorization mode (TXT api_ver, api_proto and api_auth).
 
@@ -61,7 +61,7 @@ If no Registration APIs are advertised on a network, the Node SHOULD assume peer
 
 ### DNS-SD Advertisement
 
-The preferred method of Query API advertisement is via unicast DNS-SD advertisement of the type \_nmos-query.\_tcp. Query APIs MUST additionally be capable of producing an mDNS advertisement. This MAY be disabled via a user-configurable method.
+The preferred method of Query API advertisement is via unicast DNS-SD advertisement of the type `_nmos-query._tcp`. Query APIs MUST additionally be capable of producing an mDNS advertisement. This MAY be disabled via a user-configurable method.
 
 The IP address and port of the Query API MUST be identified via the DNS-SD advertisement, with the full HTTP path then being resolved via the standard NMOS API path documentation.
 
@@ -69,28 +69,28 @@ Multiple DNS-SD advertisements for the same API are permitted where the API is e
 
 ### DNS-SD TXT Records
 
-**api\_proto**
+**api_proto**
 
-The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_proto' with a value of either 'http' or 'https' dependent on the protocol in use by the Query API web server.
+The DNS-SD advertisement MUST be accompanied by a TXT record of name `api_proto` with a value of either `http` or `https` dependent on the protocol in use by the Query API web server.
 
-**api\_ver**
+**api_ver**
 
-The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_ver'. The value of this TXT record is a comma separated list of API versions supported by the server. For example: 'v1.0,v1.1,v2.0'. There SHOULD be no whitespace between commas, and versions SHOULD be listed in ascending order.
+The DNS-SD advertisement MUST be accompanied by a TXT record of name `api_ver`. The value of this TXT record is a comma separated list of API versions supported by the server. For example: `v1.0,v1.1,v2.0`. There SHOULD be no whitespace between commas, and versions SHOULD be listed in ascending order.
 
-**api\_auth**
+**api_auth**
 
-The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_auth' with a value of either 'true' or 'false' dependent on whether authorization is needed in order to interact with the Query API or not.
+The DNS-SD advertisement MUST be accompanied by a TXT record of name `api_auth` with a value of either `true` or `false` dependent on whether authorization is needed in order to interact with the Query API or not.
 
 **pri**
 
-The DNS-SD advertisement MUST include a TXT record with key 'pri' and an integer value. Servers MAY additionally represent a matching priority via the DNS-SD SRV record 'priority' and 'weight' as defined in RFC 2782. The TXT record SHOULD be used in favour to the SRV priority and weight where these values differ in order to overcome issues in the Bonjour and Avahi implementations.
+The DNS-SD advertisement MUST include a TXT record with key `pri` and an integer value. Servers MAY additionally represent a matching priority via the DNS-SD SRV record `priority` and `weight` as defined in RFC 2782. The TXT record SHOULD be used in favour to the SRV priority and weight where these values differ in order to overcome issues in the Bonjour and Avahi implementations.
 Values 0 to 99 correspond to an active NMOS Query API (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system.
 
 ### Client Interaction Procedure
 
 1. Node (or control interface) comes online
 
-2. Node scans for an active Query API on the network using unicast and/or multicast DNS service discovery (type '\_nmos-query.\_tcp') as described in the [Discovery](3.0.%20Discovery.md#unicast-vs-multicast-dns-sd) document.
+2. Node scans for an active Query API on the network using unicast and/or multicast DNS service discovery (type `_nmos-query._tcp`) as described in the [Discovery](3.0.%20Discovery.md#unicast-vs-multicast-dns-sd) document.
 
 3. Given multiple returned Query APIs, the Node orders these based on their advertised priority (TXT pri), filtering out any APIs which do not support the desired API version, protocol and authorization mode (TXT api_ver, api_proto and api_auth).
 

--- a/docs/3.2. Discovery - Peer to Peer Operation.md
+++ b/docs/3.2. Discovery - Peer to Peer Operation.md
@@ -12,7 +12,7 @@ When configured for peer-to-peer discovery, a Node MUST advertise its presence w
 
 In the absence of a network registry, a Node MUST also indicate the validity of its API resources with mDNS TXT records.
 
-`Both of the above are properties of the [Node API](../APIs/NodeAPI.raml) and require no additional implementation steps.
+Both of the above are properties of the [Node API](../APIs/NodeAPI.raml) and require no additional implementation steps.
 
 ## DNS-SD Advertisement
 

--- a/docs/3.2. Discovery - Peer to Peer Operation.md
+++ b/docs/3.2. Discovery - Peer to Peer Operation.md
@@ -44,12 +44,12 @@ When a Node is operating in peer-to-peer mode it MUST additionally advertise the
 
 | **TXT Record Name** | **Corresponding Node API Resource** |
 |---------------------|-------------------------------------|
-| `ver_slf`            | `self`                                |
-| `ver_src`            | `sources`                             |
-| `ver_flw`            | `flows`                               |
-| `ver_dvc`            | `devices`                             |
-| `ver_snd`            | `senders`                             |
-| `ver_rcv`            | `receivers`                           |
+| `ver_slf`           | `/self`                             |
+| `ver_src`           | `/sources`                          |
+| `ver_flw`           | `/flows`                            |
+| `ver_dvc`           | `/devices`                          |
+| `ver_snd`           | `/senders`                          |
+| `ver_rcv`           | `/receivers`                        |
 
 The value of each of the above SHOULD be an unsigned 8-bit integer initialised to `0`. This integer MUST be incremented and mDNS TXT record updated whenever a change is made to the corresponding HTTP API resource on the Node. The integer MUST wrap back to a value of `0` after reaching a maximum value of `255` (MAX_UINT8_T).
 

--- a/docs/3.2. Discovery - Peer to Peer Operation.md
+++ b/docs/3.2. Discovery - Peer to Peer Operation.md
@@ -12,11 +12,11 @@ When configured for peer-to-peer discovery, a Node MUST advertise its presence w
 
 In the absence of a network registry, a Node MUST also indicate the validity of its API resources with mDNS TXT records.
 
-Both of the above are properties of the [Node API](../APIs/NodeAPI.raml) and require no additional implementation steps.
+`Both of the above are properties of the [Node API](../APIs/NodeAPI.raml) and require no additional implementation steps.
 
 ## DNS-SD Advertisement
 
-Node APIs MAY produce an mDNS advertisement of the type \_nmos-node.\_tcp in order to support peer-to-peer operation. This SHOULD NOT be advertised when a Registration API is present on the network, or when peer-to-peer operation is disabled.
+Node APIs MAY produce an mDNS advertisement of the type `_nmos-node._tcp` in order to support peer-to-peer operation. This SHOULD NOT be advertised when a Registration API is present on the network, or when peer-to-peer operation is disabled.
 
 The IP address and port of the Node API MUST be identified via the DNS-SD advertisement, with the full HTTP path then being resolved via the standard NMOS API path documentation.
 
@@ -26,43 +26,43 @@ From v1.3, Node mDNS announcements SHOULD only be used for peer to peer mode as 
 
 ## DNS-SD TXT records
 
-### api\_proto
+### `api_proto`
 
-The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_proto' with a value of either 'http' or 'https' (lower-case) dependent on the protocol in use by the Node API web server.
+The DNS-SD advertisement MUST be accompanied by a TXT record of name `api_proto` with a value of either `http` or `https` (lower-case) dependent on the protocol in use by the Node API web server.
 
-### api\_ver
+### `api_ver`
 
-The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_ver'. The value of this TXT record is a comma separated list of API versions supported by the server. For example: 'v1.0,v1.1,v2.0'. There SHOULD be no whitespace between commas, and versions SHOULD be listed in ascending order.
+The DNS-SD advertisement MUST be accompanied by a TXT record of name `api_ver`. The value of this TXT record is a comma separated list of API versions supported by the server. For example: `v1.0,v1.1,v2.0`. There SHOULD be no whitespace between commas, and versions SHOULD be listed in ascending order.
 
-### api\_auth
+### `api_auth`
 
-The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_auth' with a value of either 'true' or 'false' dependent on whether authorization is needed for Node API requests.
+The DNS-SD advertisement MUST be accompanied by a TXT record of name `api_auth` with a value of either `true` or `false` dependent on whether authorization is needed for Node API requests.
 
-### ver\_
+### `ver_`
 
 When a Node is operating in peer-to-peer mode it MUST additionally advertise the following mDNS TXT records as part of its Node advertisement. If a Node is successfully registered with a Registration API it MUST withdraw advertisements of these TXT records. There is no requirement to register these TXT records with a unicast DNS service.
 
 | **TXT Record Name** | **Corresponding Node API Resource** |
 |---------------------|-------------------------------------|
-| ver\_slf            | self                                |
-| ver\_src            | sources                             |
-| ver\_flw            | flows                               |
-| ver\_dvc            | devices                             |
-| ver\_snd            | senders                             |
-| ver\_rcv            | receivers                           |
+| `ver_slf`            | `self`                                |
+| `ver_src`            | `sources`                             |
+| `ver_flw`            | `flows`                               |
+| `ver_dvc`            | `devices`                             |
+| `ver_snd`            | `senders`                             |
+| `ver_rcv`            | `receivers`                           |
 
-The value of each of the above SHOULD be an unsigned 8-bit integer initialised to '0'. This integer MUST be incremented and mDNS TXT record updated whenever a change is made to the corresponding HTTP API resource on the Node. The integer MUST wrap back to a value of '0' after reaching a maximum value of '255' (MAX_UINT8_T).
+The value of each of the above SHOULD be an unsigned 8-bit integer initialised to `0`. This integer MUST be incremented and mDNS TXT record updated whenever a change is made to the corresponding HTTP API resource on the Node. The integer MUST wrap back to a value of `0` after reaching a maximum value of `255` (MAX_UINT8_T).
 
-For example, the 'ver_src' TXT record MUST be created when the Node first advertises itself via mDNS. If the data held within the HTTP resource for /sources is added to, removed from or edited, then the 'ver_src' text record MUST be modified (value incremented).
+For example, the `ver_src` TXT record MUST be created when the Node first advertises itself via mDNS. If the data held within the HTTP resource for `/sources` is added to, removed from or edited, then the `ver_src` text record MUST be modified (value incremented).
 
 ### Client Interaction Procedure
 
 The following scenario describes a peer-to-peer discovery in which a Node features an onboard control interface (for example a display with an input source menu).
 
 1. Node comes online
-2. Node scans for an active Query API on the network (type '\_nmos-query.\_tcp')
-3. Given no active Query API, Node scans mDNS for other Nodes (type '\_nmos-node.\_tcp')
-4. Using the returned list of Nodes, the requesting Node can request data from remote Node API resources as needed to populate a control interface. This could be as simple as requesting the '/senders' resource.
+2. Node scans for an active Query API on the network (type `_nmos-query._tcp`)
+3. Given no active Query API, Node scans mDNS for other Nodes (type `_nmos-node._tcp`)
+4. Using the returned list of Nodes, the requesting Node can request data from remote Node API resources as needed to populate a control interface. This could be as simple as requesting the `/senders` resource.
 5. The Node continues to monitor for changes to Node advertisements via mDNS. When Node API resources are changed, the TXT records associated with each Node will be updated to indicate which API resource(s) have been updated (see [Node API specification](../APIs/NodeAPI.raml))
 6. The Node SHOULD not re-poll remote Nodes on a timer in order to gather data about updated API resources
 7. The Node can perform connection management tasks automatically without user intervention provided they only affect that Node's operation. This includes but is not limited to automatically routing video from a discovered Sender to a display's Receiver

--- a/docs/3.2. Discovery - Peer to Peer Operation.md
+++ b/docs/3.2. Discovery - Peer to Peer Operation.md
@@ -4,7 +4,7 @@ _(c) AMWA 2016, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 This document describes usage of NMOS APIs for discovery in cases where where a distributed registry is not available, such as small ad-hoc installations. This feature is OPTIONAL from v1.3 of the specification.
 
-Note that the peer-to-peer discovery mechanism depends upon mDNS which is not intended to operate over IP routed boundaries (ie. between network subnets). As such it is RECOMMENDED that for most use cases, in particular fixed installations and those requiring high levels of resilience, the registered discovery mechanism is used.
+Note that the peer-to-peer discovery mechanism depends upon mDNS which is not intended to operate over IP routed boundaries (i.e. between network subnets). As such it is RECOMMENDED that for most use cases, in particular fixed installations and those requiring high levels of resilience, the registered discovery mechanism is used.
 
 ## Pre-Requisites
 

--- a/docs/4.1. Behaviour - Registration.md
+++ b/docs/4.1. Behaviour - Registration.md
@@ -81,13 +81,13 @@ The following error conditions describe likely scenarios encountered by Nodes wh
 
 ### Node Encounters HTTP 200 On First Registration
 
-If a Node is restarted, its first action upon discovering a Registration API is to register its Node resource. On first registration with a Registration API this SHOULD result in a 201 (Created) HTTP response code. If a Node receives a 200 code in this case, a previous record of the Node can be assumed to still exist within the network registry. In order to avoid the registry-held representation of the Node's resources from being out of sync with the Node's view, an HTTP `DELETE` SHOULD be performed in this situation to explicitly clear the registry of the Node and any sub-resources. A new Node registration after this point SHOULD result in the correct 201 response code.
+If a Node is restarted, its first action upon discovering a Registration API is to register its Node resource. On first registration with a Registration API this SHOULD result in a 201 (Created) HTTP response code. If a Node receives a 200 (OK) code in this case, a previous record of the Node can be assumed to still exist within the network registry. In order to avoid the registry-held representation of the Node's resources from being out of sync with the Node's view, an HTTP `DELETE` SHOULD be performed in this situation to explicitly clear the registry of the Node and any sub-resources. A new Node registration after this point SHOULD result in the correct 201 (Created) response code.
 
 ### Node Encounters HTTP 400 (Or Other Undocumented 4xx) On Registration
 
-A 400 error indicates a client error which is likely to be the result of a validation failure identified by the Registration API. The same request MUST NOT be re-attempted without corrective action being taken first.
+A 400 (Bad Request) error indicates a client error which is likely to be the result of a validation failure identified by the Registration API. The same request MUST NOT be re-attempted without corrective action being taken first.
 
-A registry MAY issue a 400 code from the `/resource` `POST` endpoint for various reasons, including the following cases. It is not expected that a Node will be able to automatically handle these errors and user intervention could be necessary.
+A registry MAY issue a 400 (Bad Request) code from the `/resource` `POST` endpoint for various reasons, including the following cases. It is not expected that a Node will be able to automatically handle these errors and user intervention could be necessary.
 
 - The request body does not meet the JSON schema for that resource type
 - The `id` included in the request has already been used by another resource type held in the registry
@@ -99,17 +99,17 @@ Error responses as detailed in the [APIs](2.0.%20APIs.md) documentation can assi
 
 ### Node Encounters HTTP 409 On Registration Or Heartbeat
 
-A 409 error indicates that the Node has attempted to register or heartbeat with a registry which it is already registered with using a different API version. The Node MUST fully unregister from this registry using its registered API version before proceeding to re-register at the new API version. For more information on supporting multiple versions, see the [Upgrade Path](6.0.%20Upgrade%20Path.md).
+A 409 (Conflict) error indicates that the Node has attempted to register or heartbeat with a registry which it is already registered with using a different API version. The Node MUST fully unregister from this registry using its registered API version before proceeding to re-register at the new API version. For more information on supporting multiple versions, see the [Upgrade Path](6.0.%20Upgrade%20Path.md).
 
 ### Node Encounters HTTP 404 On Heartbeat
 
-A 404 error on heartbeat indicates that the Node performing the heartbeat is not known to the Registration API. This could be as a result of a number of missed heartbeats which triggered garbage collection in the Registration API. On encountering this code, a Node MUST re-register each of its resources with the Registration API in order.
+A 404 (Not Found) error on heartbeat indicates that the Node performing the heartbeat is not known to the Registration API. This could be as a result of a number of missed heartbeats which triggered garbage collection in the Registration API. On encountering this code, a Node MUST re-register each of its resources with the Registration API in order.
 
 ### Node Encounters HTTP 500 (or other 5xx), Inability To Connect, Or A Timeout
 
-A 500 error, inability to connect or a timeout indicates a server side or connectivity issue. As this issue could affect just one Registration API in a cluster, it is advised that clients identify another Registration API to use from their discovered list. The first interaction with a new Registration API in this case SHOULD be a heartbeat to confirm whether the Node is still present in the registry.
+A 500 (Internal Server Error) error, inability to connect or a timeout indicates a server side or connectivity issue. As this issue could affect just one Registration API in a cluster, it is advised that clients identify another Registration API to use from their discovered list. The first interaction with a new Registration API in this case SHOULD be a heartbeat to confirm whether the Node is still present in the registry.
 
-When performing the initial heartbeat with a new Registration API, a 200 code indicates that the Node and its resources are still present in the registry cluster and no further action is necessary. Future registrations and heartbeats SHOULD be performed against this new Registration API. If a 404 code is encountered when performing this heartbeat, refer to 'Node Encounters HTTP 404 On Heartbeat' above.
+When performing the initial heartbeat with a new Registration API, a 200 (OK) code indicates that the Node and its resources are still present in the registry cluster and no further action is necessary. Future registrations and heartbeats SHOULD be performed against this new Registration API. If a 404 (Not Found) code is encountered when performing this heartbeat, refer to 'Node Encounters HTTP 404 On Heartbeat' above.
 
 Note that in order to achieve efficient failover from one Registration API to another, the Node needs to perform its first heartbeat with the new Registration API within the garbage collection interval following its most recent successful heartbeat. It is therefore advised that Nodes use the heartbeat interval to define their connection timeouts for `/health/nodes/{nodeId}` `POST` requests.
 

--- a/docs/4.1. Behaviour - Registration.md
+++ b/docs/4.1. Behaviour - Registration.md
@@ -28,7 +28,7 @@ NMOS models this as a single Flow sent via two independent Senders which are ass
 
 This mode of operation is applicable to both 'peer-to-peer' and 'registered' discovery. Registered discovery MAY use either a single registry, or an independent registry for each network.
 
-In order to support this mode and ensure persistence in the registry upon link failure, a Node operating in this mode MAY register with Registration APIs (and host its Node API) via multiple independent network interfaces. If separate registries are deployed for the multiple network links the Node MUST ensure it registers the correct 'href' with each registry (see [Node API](../APIs/NodeAPI.raml) `/self` resource). From v1.1, the 'api' attribute of the Node /self resource adds the capability to list multiple endpoints for the same Node API, removing the requirement for this 'href' specialisation.
+In order to support this mode and ensure persistence in the registry upon link failure, a Node operating in this mode MAY register with Registration APIs (and host its Node API) via multiple independent network interfaces. If separate registries are deployed for the multiple network links the Node MUST ensure it registers the correct `href` with each registry (see [Node API](../APIs/NodeAPI.raml) `/self` resource). From v1.1, the `api` attribute of the Node `/self` resource adds the capability to list multiple endpoints for the same Node API, removing the requirement for this `href` specialisation.
 
 ![Registration example with two independent networks and registries](images/redundant-reg.png)
 

--- a/docs/4.1. Behaviour - Registration.md
+++ b/docs/4.1. Behaviour - Registration.md
@@ -14,11 +14,11 @@ The following behaviour assumes a Node with a single network interface for all t
 
 1. A Node is connected to the network.
 2. The Node runs an HTTP accessible Node API.
-3. The Node produces an mDNS advertisement of type '\_nmos-node.\_tcp' in the '.local' domain as specified in [Node API](../APIs/NodeAPI.raml).
-4. The Node performs a DNS-SD browse for services of type '\_nmos-register.\_tcp' as specified in [Discovery: Registered Operation](3.1.%20Discovery%20-%20Registered%20Operation.md).
-5. The Node registers itself with the Registration API by taking the object it holds under the Node API's /self resource and `POST`ing this to the Registration API.
+3. The Node produces an mDNS advertisement of type `_nmos-node._tcp` in the `.local` domain as specified in [Node API](../APIs/NodeAPI.raml).
+4. The Node performs a DNS-SD browse for services of type `_nmos-register._tcp` as specified in [Discovery: Registered Operation](3.1.%20Discovery%20-%20Registered%20Operation.md).
+5. The Node registers itself with the Registration API by taking the object it holds under the Node API's `/self` resource and `POST`ing this to the Registration API.
 6. The Node persists itself in the registry by issuing heartbeats as below.
-7. The Node registers its other resources (from /devices, /sources etc) with the Registration API. Resources MUST be registered in the correct order, such that a Receiver which references a device_id is registered after that corresponding Device (for example).
+7. The Node registers its other resources (from `/devices`, `/sources`, etc.) with the Registration API. Resources MUST be registered in the correct order, such that a Receiver which references a `device_id` is registered after that corresponding Device (for example).
 
 #### Resilient Node Behaviour
 
@@ -55,7 +55,7 @@ A Node SHOULD register resources in the following order to avoid rejections due 
 5. Senders: Referencing parent Device via device_id attribute
 6. Receivers: Referencing parent Device via device_id attribute
 
-(\*) Version v1.0 Flows do not have a device_id and SHOULD be garbage collected based on their parent source_id.
+(\*) Version v1.0 Flows do not have a `device_id` and SHOULD be garbage collected based on their parent `source_id`.
 
 Where a `DELETE` is issued against a parent resource, all child resources MUST be removed from the registry immediately.
 

--- a/docs/4.1. Behaviour - Registration.md
+++ b/docs/4.1. Behaviour - Registration.md
@@ -16,7 +16,7 @@ The following behaviour assumes a Node with a single network interface for all t
 2. The Node runs an HTTP accessible Node API.
 3. The Node produces an mDNS advertisement of type '\_nmos-node.\_tcp' in the '.local' domain as specified in [Node API](../APIs/NodeAPI.raml).
 4. The Node performs a DNS-SD browse for services of type '\_nmos-register.\_tcp' as specified in [Discovery: Registered Operation](3.1.%20Discovery%20-%20Registered%20Operation.md).
-5. The Node registers itself with the Registration API by taking the object it holds under the Node API's /self resource and POSTing this to the Registration API.
+5. The Node registers itself with the Registration API by taking the object it holds under the Node API's /self resource and `POST`ing this to the Registration API.
 6. The Node persists itself in the registry by issuing heartbeats as below.
 7. The Node registers its other resources (from /devices, /sources etc) with the Registration API. Resources MUST be registered in the correct order, such that a Receiver which references a device_id is registered after that corresponding Device (for example).
 
@@ -34,7 +34,7 @@ In order to support this mode and ensure persistence in the registry upon link f
 
 ### Heartbeating
 
-Nodes SHOULD perform a heartbeat every 5 seconds by default, by making HTTP POST requests to the `/health/nodes/{nodeId}` endpoint.
+Nodes SHOULD perform a heartbeat every 5 seconds by default, by making HTTP `POST` requests to the `/health/nodes/{nodeId}` endpoint.
 
 Registration APIs SHOULD use a garbage collection interval of 12 seconds by default (triggered just after two failed heartbeats at the default 5 second interval).
 
@@ -57,11 +57,11 @@ A Node SHOULD register resources in the following order to avoid rejections due 
 
 (\*) Version v1.0 Flows do not have a device_id and SHOULD be garbage collected based on their parent source_id.
 
-Where a DELETE is issued against a parent resource, all child resources MUST be removed from the registry immediately.
+Where a `DELETE` is issued against a parent resource, all child resources MUST be removed from the registry immediately.
 
 ### Controlled Unregistration
 
-Nodes SHOULD attempt to remove themselves from the registry cleanly on shutdown. This requires HTTP DELETE requests to be made for each resource registered via the Registration API. These DELETEs SHOULD be carried out on child resources followed by their parents (e.g. Sources which have child Flows are deleted after their children etc.)
+Nodes SHOULD attempt to remove themselves from the registry cleanly on shutdown. This requires HTTP `DELETE` requests to be made for each resource registered via the Registration API. These `DELETE`s SHOULD be carried out on child resources followed by their parents (e.g. Sources which have child Flows are deleted after their children etc.)
 
 If a Node unregisters a resource in the incorrect order, the Registration API MUST clean up related child resources on the Node's behalf in order to prevent stale entries remaining in the registry.
 
@@ -81,13 +81,13 @@ The following error conditions describe likely scenarios encountered by Nodes wh
 
 ### Node Encounters HTTP 200 On First Registration
 
-If a Node is restarted, its first action upon discovering a Registration API is to register its 'Node' resource. On first registration with a Registration API this SHOULD result in a '201 Created' HTTP response code. If a Node receives a 200 code in this case, a previous record of the Node can be assumed to still exist within the network registry. In order to avoid the registry-held representation of the Node's resources from being out of sync with the Node's view, an HTTP DELETE SHOULD be performed in this situation to explicitly clear the registry of the Node and any sub-resources. A new Node registration after this point SHOULD result in the correct 201 response code.
+If a Node is restarted, its first action upon discovering a Registration API is to register its 'Node' resource. On first registration with a Registration API this SHOULD result in a '201 Created' HTTP response code. If a Node receives a 200 code in this case, a previous record of the Node can be assumed to still exist within the network registry. In order to avoid the registry-held representation of the Node's resources from being out of sync with the Node's view, an HTTP `DELETE` SHOULD be performed in this situation to explicitly clear the registry of the Node and any sub-resources. A new Node registration after this point SHOULD result in the correct 201 response code.
 
 ### Node Encounters HTTP 400 (Or Other Undocumented 4xx) On Registration
 
 A 400 error indicates a client error which is likely to be the result of a validation failure identified by the Registration API. The same request MUST NOT be re-attempted without corrective action being taken first.
 
-A registry MAY issue a 400 code from the `/resource` POST endpoint for various reasons, including the following cases. It is not expected that a Node will be able to automatically handle these errors and user intervention could be necessary.
+A registry MAY issue a 400 code from the `/resource` `POST` endpoint for various reasons, including the following cases. It is not expected that a Node will be able to automatically handle these errors and user intervention could be necessary.
 
 - The request body does not meet the JSON schema for that resource type
 - The 'id' included in the request has already been used by another resource type held in the registry
@@ -111,6 +111,6 @@ A 500 error, inability to connect or a timeout indicates a server side or connec
 
 When performing the initial heartbeat with a new Registration API, a 200 code indicates that the Node and its resources are still present in the registry cluster and no further action is necessary. Future registrations and heartbeats SHOULD be performed against this new Registration API. If a 404 code is encountered when performing this heartbeat, refer to 'Node Encounters HTTP 404 On Heartbeat' above.
 
-Note that in order to achieve efficient failover from one Registration API to another, the Node needs to perform its first heartbeat with the new Registration API within the garbage collection interval following its most recent successful heartbeat. It is therefore advised that Nodes use the heartbeat interval to define their connection timeouts for `/health/nodes/{nodeId}` POST requests.
+Note that in order to achieve efficient failover from one Registration API to another, the Node needs to perform its first heartbeat with the new Registration API within the garbage collection interval following its most recent successful heartbeat. It is therefore advised that Nodes use the heartbeat interval to define their connection timeouts for `/health/nodes/{nodeId}` `POST` requests.
 
 If a 5xx error is encountered when interacting with all discoverable Registration APIs, clients SHOULD implement an exponential backoff algorithm in their next attempts until a non-5xx response code is received.

--- a/docs/4.1. Behaviour - Registration.md
+++ b/docs/4.1. Behaviour - Registration.md
@@ -40,7 +40,7 @@ Registration APIs SHOULD use a garbage collection interval of 12 seconds by defa
 
 It is RECOMMENDED that heartbeat and garbage collection intervals are user-configurable to non-default values in Nodes and Registration APIs respectively. The garbage collection interval MAY be increased without any adverse effects on the registering Nodes. To decrease the garbage collection interval, or increase the heartbeat interval, a system-wide configuration is REQUIRED (see [IS-09](https://specs.amwa.tv/is-09)).
 
-Nodes only need perform a heartbeat to maintain their 'Node' resource in the Registration API. If heartbeats fail over a period greater than the garbage collection interval, both the Node and all registered sub-resources SHOULD be removed from the registry automatically.
+Nodes only need perform a heartbeat to maintain their Node resource in the Registration API. If heartbeats fail over a period greater than the garbage collection interval, both the Node and all registered sub-resources SHOULD be removed from the registry automatically.
 
 ### Referential Integrity
 
@@ -49,13 +49,13 @@ In order to permit garbage collection, resources MUST only be accepted by a Regi
 A Node SHOULD register resources in the following order to avoid rejections due to referential integrity issues:
 
 1. Node: Root entity, which is persisted via heartbeats
-2. Devices: Referencing parent Node via node_id attribute
-3. Sources: Referencing parent Device via device_id attribute
-4. Flows: Referencing parent Device via device_id attribute (\*)
-5. Senders: Referencing parent Device via device_id attribute
-6. Receivers: Referencing parent Device via device_id attribute
+2. Devices: Referencing parent Node via `node_id` attribute
+3. Sources: Referencing parent Device via `device_id` attribute
+4. Flows: Referencing parent Device via `device_id` attribute\*
+5. Senders: Referencing parent Device via `device_id` attribute
+6. Receivers: Referencing parent Device via `device_id` attribute
 
-(\*) Version v1.0 Flows do not have a `device_id` and SHOULD be garbage collected based on their parent `source_id`.
+\* Version v1.0 Flows do not have a `device_id` and SHOULD be garbage collected based on their parent `source_id`.
 
 Where a `DELETE` is issued against a parent resource, all child resources MUST be removed from the registry immediately.
 
@@ -81,7 +81,7 @@ The following error conditions describe likely scenarios encountered by Nodes wh
 
 ### Node Encounters HTTP 200 On First Registration
 
-If a Node is restarted, its first action upon discovering a Registration API is to register its 'Node' resource. On first registration with a Registration API this SHOULD result in a '201 Created' HTTP response code. If a Node receives a 200 code in this case, a previous record of the Node can be assumed to still exist within the network registry. In order to avoid the registry-held representation of the Node's resources from being out of sync with the Node's view, an HTTP `DELETE` SHOULD be performed in this situation to explicitly clear the registry of the Node and any sub-resources. A new Node registration after this point SHOULD result in the correct 201 response code.
+If a Node is restarted, its first action upon discovering a Registration API is to register its Node resource. On first registration with a Registration API this SHOULD result in a 201 (Created) HTTP response code. If a Node receives a 200 code in this case, a previous record of the Node can be assumed to still exist within the network registry. In order to avoid the registry-held representation of the Node's resources from being out of sync with the Node's view, an HTTP `DELETE` SHOULD be performed in this situation to explicitly clear the registry of the Node and any sub-resources. A new Node registration after this point SHOULD result in the correct 201 response code.
 
 ### Node Encounters HTTP 400 (Or Other Undocumented 4xx) On Registration
 
@@ -90,9 +90,9 @@ A 400 error indicates a client error which is likely to be the result of a valid
 A registry MAY issue a 400 code from the `/resource` `POST` endpoint for various reasons, including the following cases. It is not expected that a Node will be able to automatically handle these errors and user intervention could be necessary.
 
 - The request body does not meet the JSON schema for that resource type
-- The 'id' included in the request has already been used by another resource type held in the registry
-- The 'version' included in the request is earlier than the matching resource already held in the registry
-- A parent resource ID has been modified (for example the 'node_id' in a Device registration is modified during an update)
+- The `id` included in the request has already been used by another resource type held in the registry
+- The `version` included in the request is earlier than the matching resource already held in the registry
+- A parent resource ID has been modified (for example the `node_id` in a Device registration is modified during an update)
 - The parent resource referred to either doesn't exist in the registry or the ID matches the wrong type of resource
 
 Error responses as detailed in the [APIs](2.0.%20APIs.md) documentation can assist with debugging these issues.

--- a/docs/4.2. Behaviour - Querying.md
+++ b/docs/4.2. Behaviour - Querying.md
@@ -10,9 +10,9 @@ Where the behaviour associated with an API attribute is not sufficiently clear f
 
 ### Subscriptions
 
-`secure`: Indicates whether the WebSocket connection is provided via an encrypted connection (`ws://` vs. `wss://`). Unless otherwise indicated the value of this attribute SHOULD be `false` if the API is being presented via HTTP, and `true` for HTTPS. Query API clients MAY choose to specify the opposite value in requests for subscriptions, however they will receive a 400 response code unless the Query API explicitly supports a mismatch between encrypted HTTP and WebSocket connections.
+`secure`: Indicates whether the WebSocket connection is provided via an encrypted connection (`ws://` vs. `wss://`). Unless otherwise indicated the value of this attribute SHOULD be `false` if the API is being presented via HTTP, and `true` for HTTPS. Query API clients MAY choose to specify the opposite value in requests for subscriptions, however they will receive a 400 (Bad Request) response code unless the Query API explicitly supports a mismatch between encrypted HTTP and WebSocket connections.
 
-`authorization`: Indicates whether the WebSocket connection requires authorization in order to connect. Use of authorization is likely to be a deployment decision and be the same for all subscriptions exposed from a single Query API, and for the RESTful API itself. Query API clients MAY specify a requested value for this attribute, but in most circumstances this will result in a 400 response code if the Query API is operating in the opposite mode.
+`authorization`: Indicates whether the WebSocket connection requires authorization in order to connect. Use of authorization is likely to be a deployment decision and be the same for all subscriptions exposed from a single Query API, and for the RESTful API itself. Query API clients MAY specify a requested value for this attribute, but in most circumstances this will result in a 400 (Bad Request) response code if the Query API is operating in the opposite mode.
 
 ## Creating a WebSocket subscription
 
@@ -30,7 +30,7 @@ Long-lived connections to the Query API are supported via WebSockets which can b
 
 Upon receiving a request for a new subscription, the Query API SHOULD identify whether it already has any WebSockets open which provide for the requested query. If a WebSocket exists, the `subscription` object representing it MAY be returned to the user. If a relevant WebSocket does not exist a new one SHOULD be created.
 
-In normal operation, once a WebSocket has no more clients subscribed to it the Query API MAY automatically remove it and its corresponding HTTP-advertised subscription object. The Query API MUST NOT acknowledge HTTP `DELETE` requests for WebSockets running in this 'non-persistent' mode, instead issuing an HTTP 403 response.
+In normal operation, once a WebSocket has no more clients subscribed to it the Query API MAY automatically remove it and its corresponding HTTP-advertised subscription object. The Query API MUST NOT acknowledge HTTP `DELETE` requests for WebSockets running in this 'non-persistent' mode, instead issuing an HTTP 403 (Forbidden) response.
 
 If a 'persistent' WebSocket has been requested by the client, this MUST NOT be cleaned up automatically by the Query API, even if all consuming clients have disconnected. The user MAY request closing of this socket by issuing an HTTP `DELETE`. If an HTTP `DELETE` is issued prior to all WebSocket connections being closed, they SHOULD be forcibly closed by the server.
 

--- a/docs/4.2. Behaviour - Querying.md
+++ b/docs/4.2. Behaviour - Querying.md
@@ -10,9 +10,9 @@ Where the behaviour associated with an API attribute is not sufficiently clear f
 
 ### Subscriptions
 
-`secure` Indicates whether the WebSocket connection is provided via an encrypted connection (`ws://` vs. `wss://`). Unless otherwise indicated the value of this attribute SHOULD be `false` if the API is being presented via HTTP, and `true` for HTTPS. Query API clients MAY choose to specify the opposite value in requests for subscriptions, however they will receive a 400 response code unless the Query API explicitly supports a mismatch between encrypted HTTP and WebSocket connections.
+`secure`: Indicates whether the WebSocket connection is provided via an encrypted connection (`ws://` vs. `wss://`). Unless otherwise indicated the value of this attribute SHOULD be `false` if the API is being presented via HTTP, and `true` for HTTPS. Query API clients MAY choose to specify the opposite value in requests for subscriptions, however they will receive a 400 response code unless the Query API explicitly supports a mismatch between encrypted HTTP and WebSocket connections.
 
-`authorization` Indicates whether the WebSocket connection requires authorization in order to connect. Use of authorization is likely to be a deployment decision and be the same for all subscriptions exposed from a single Query API, and for the RESTful API itself. Query API clients MAY specify a requested value for this attribute, but in most circumstances this will result in a 400 response code if the Query API is operating in the opposite mode.
+`authorization`: Indicates whether the WebSocket connection requires authorization in order to connect. Use of authorization is likely to be a deployment decision and be the same for all subscriptions exposed from a single Query API, and for the RESTful API itself. Query API clients MAY specify a requested value for this attribute, but in most circumstances this will result in a 400 response code if the Query API is operating in the opposite mode.
 
 ## Creating a WebSocket subscription
 

--- a/docs/4.2. Behaviour - Querying.md
+++ b/docs/4.2. Behaviour - Querying.md
@@ -32,7 +32,7 @@ Upon receiving a request for a new subscription, the Query API SHOULD identify w
 
 In normal operation, once a WebSocket has no more clients subscribed to it the Query API MAY automatically remove it and its corresponding HTTP-advertised subscription object. The Query API MUST NOT acknowledge HTTP `DELETE` requests for WebSockets running in this 'non-persistent' mode, instead issuing an HTTP 403 response.
 
-If a 'persistent' WebSocket has been requested by the client, this MUST NOT be cleaned up automatically by the Query API, even if all consuming clients have disconnected. The user MAY request closing of this socket by issuing an HTTP DELETE. If an HTTP DELETE is issued prior to all WebSocket connections being closed, they SHOULD be forcibly closed by the server.
+If a 'persistent' WebSocket has been requested by the client, this MUST NOT be cleaned up automatically by the Query API, even if all consuming clients have disconnected. The user MAY request closing of this socket by issuing an HTTP `DELETE`. If an HTTP `DELETE` is issued prior to all WebSocket connections being closed, they SHOULD be forcibly closed by the server.
 
 ### WebSocket Protocol
 

--- a/docs/4.2. Behaviour - Querying.md
+++ b/docs/4.2. Behaviour - Querying.md
@@ -183,7 +183,7 @@ Event data containing both `pre` and `post` attributes signifies modification of
 
 #### Resource(s) Unchanged (Sync) Event
 
-Event data containing both  `pre ` and  `post ` where the contents of  `pre ` and  `post ` are identical. This is used in initial synchronisation messages to ensure the client has received all data for a given topic.
+Event data containing both  `pre` and  `post` where the contents of  `pre` and  `post` are identical. This is used in initial synchronisation messages to ensure the client has received all data for a given topic.
 
 ```json
 {

--- a/docs/4.2. Behaviour - Querying.md
+++ b/docs/4.2. Behaviour - Querying.md
@@ -10,7 +10,7 @@ Where the behaviour associated with an API attribute is not sufficiently clear f
 
 ### Subscriptions
 
-`secure` Indicates whether the WebSocket connection is provided via an encrypted connection (ws:// vs. wss://). Unless otherwise indicated the value of this attribute SHOULD be 'false' if the API is being presented via HTTP, and 'true' for HTTPS. Query API clients MAY choose to specify the opposite value in requests for subscriptions, however they will receive a 400 response code unless the Query API explicitly supports a mismatch between encrypted HTTP and WebSocket connections.
+`secure` Indicates whether the WebSocket connection is provided via an encrypted connection (`ws://` vs. `wss://`). Unless otherwise indicated the value of this attribute SHOULD be `false` if the API is being presented via HTTP, and `true` for HTTPS. Query API clients MAY choose to specify the opposite value in requests for subscriptions, however they will receive a 400 response code unless the Query API explicitly supports a mismatch between encrypted HTTP and WebSocket connections.
 
 `authorization` Indicates whether the WebSocket connection requires authorization in order to connect. Use of authorization is likely to be a deployment decision and be the same for all subscriptions exposed from a single Query API, and for the RESTful API itself. Query API clients MAY specify a requested value for this attribute, but in most circumstances this will result in a 400 response code if the Query API is operating in the opposite mode.
 
@@ -18,7 +18,7 @@ Where the behaviour associated with an API attribute is not sufficiently clear f
 
 In order to connect to a WebSocket, a client MUST first request a subscription of a particular type and with particular query parameters by performing a POST as defined in the [Query API](../APIs/QueryAPI.raml) subscriptions documentation. Use of GET requests to find existing suitable WebSocket connections is strongly discouraged.
 
-There is no mandated URL base path for servers to use when creating WebSocket connections. Instead clients SHOULD observe the value of 'ws_href' which is returned by their subscription request in order to identify what to connect to.
+There is no mandated URL base path for servers to use when creating WebSocket connections. Instead clients SHOULD observe the value of `ws_href` which is returned by their subscription request in order to identify what to connect to.
 
 WebSockets created for specific clients will be cleaned up automatically if they disconnect.
 
@@ -26,9 +26,9 @@ Connection upgrade procedures permitting an existing HTTP query to transition to
 
 ### Query API Behaviour
 
-Long-lived connections to the Query API are supported via WebSockets which can be set up via the /subscriptions resource. Query APIs MAY additionally support the HTTP 'Upgrade' header sent by clients to upgrade an HTTP GET request to a WebSocket. In cases where this is performed, a corresponding entry in /subscriptions MUST also be created with matching query parameters.
+Long-lived connections to the Query API are supported via WebSockets which can be set up via the `/subscriptions` resource. Query APIs MAY additionally support the HTTP `Upgrade` header sent by clients to upgrade an HTTP GET request to a WebSocket. In cases where this is performed, a corresponding entry in `/subscriptions` MUST also be created with matching query parameters.
 
-Upon receiving a request for a new subscription, the Query API SHOULD identify whether it already has any WebSockets open which provide for the requested query. If a WebSocket exists, the 'subscription' object representing it MAY be returned to the user. If a relevant WebSocket does not exist a new one SHOULD be created.
+Upon receiving a request for a new subscription, the Query API SHOULD identify whether it already has any WebSockets open which provide for the requested query. If a WebSocket exists, the `subscription` object representing it MAY be returned to the user. If a relevant WebSocket does not exist a new one SHOULD be created.
 
 In normal operation, once a WebSocket has no more clients subscribed to it the Query API MAY automatically remove it and its corresponding HTTP-advertised subscription object. The Query API MUST NOT acknowledge HTTP DELETE requests for WebSockets running in this 'non-persistent' mode, instead issuing an HTTP 403 response.
 
@@ -38,7 +38,7 @@ If a 'persistent' WebSocket has been requested by the client, this MUST NOT be c
 
 Using data Grains, the WebSocket protocol provides a client with the current state of the contents of the registry at the time of subscription. It subsequently notifies clients of any changes.
 
-Note that the Source ID used in the following examples references the Query API instance. The Flow ID then corresponds to the subscription ID created via the /subscriptions HTTP resource.
+Note that the Source ID used in the following examples references the Query API instance. The Flow ID then corresponds to the subscription ID created via the `/subscriptions` HTTP resource.
 
 The timestamps used in these messages are as follows:
 
@@ -48,15 +48,15 @@ The timestamps used in these messages are as follows:
 
 The three timestamps MAY be identical. For more details of the timing model used in NMOS specifications, see [MS-04](https://specs.amwa.tv/ms-04/).
 
-The 'rate' and 'duration' attributes MAY be ignored by clients as the event messages being exchanged do not adhere to a defined rate or duration.
+The `rate` and `duration` attributes MAY be ignored by clients as the event messages being exchanged do not adhere to a defined rate or duration.
 
-Each Grain MAY contain one or more objects in its 'data' array. Each object identifies a change to a single Source, Flow or other resource as identified by the 'topic'.
+Each Grain MAY contain one or more objects in its `data` array. Each object identifies a change to a single Source, Flow or other resource as identified by the `topic`.
 
 A schema for the Grain metadata described below is available [here](../APIs/schemas/queryapi-subscriptions-websocket.json).
 
 #### Resource(s) Added Event
 
-Event data containing only a "post" attribute signifies creation of a resource.
+Event data containing only a `post` attribute signifies creation of a resource.
 
 ```json
 {
@@ -96,7 +96,7 @@ Event data containing only a "post" attribute signifies creation of a resource.
 
 #### Resource(s) Removed Event
 
-Event data containing only a "pre" attribute signifies deletion of a resource.
+Event data containing only a `pre` attribute signifies deletion of a resource.
 
 ```json
 {
@@ -136,7 +136,7 @@ Event data containing only a "pre" attribute signifies deletion of a resource.
 
 #### Resource(s) Modified Event
 
-Event data containing both "pre" and "post" attributes signifies modification of a resource. All attributes of the resource MUST be specified (i.e. not just those that have changed).
+Event data containing both `pre` and `post` attributes signifies modification of a resource. All attributes of the resource MUST be specified (i.e. not just those that have changed).
 
 ```json
 {
@@ -183,7 +183,7 @@ Event data containing both "pre" and "post" attributes signifies modification of
 
 #### Resource(s) Unchanged (Sync) Event
 
-Event data containing both "pre" and "post" where the contents of "pre" and "post" are identical. This is used in initial synchronisation messages to ensure the client has received all data for a given topic.
+Event data containing both  `pre ` and  `post ` where the contents of  `pre ` and  `post ` are identical. This is used in initial synchronisation messages to ensure the client has received all data for a given topic.
 
 ```json
 {
@@ -249,8 +249,8 @@ Event data containing both "pre" and "post" where the contents of "pre" and "pos
 
 WebSocket subscriptions support query parameters in the same way as the corresponding REST API endpoints. Subscriptions MUST inform clients when resources begin to match, or no longer match, a given query parameter. For example:
 
-- If a Flow (or other resource) has a 'tag' removed causing it to no longer match the query parameters for a WebSocket subscription, the client MUST be issued a 'Resource Removed Event' as if this resource had been deleted from the registry.
-- If a Flow (or other resource) has a 'tag' added causing it to match a query parameter where it didn't match them previously, the client MUST be issued a 'Resource Added Event' as if this resource had been freshly created in the registry.
+- If a Flow (or other resource) has a `tag` removed causing it to no longer match the query parameters for a WebSocket subscription, the client MUST be issued a 'Resource Removed Event' as if this resource had been deleted from the registry.
+- If a Flow (or other resource) has a `tag` added causing it to match a query parameter where it didn't match them previously, the client MUST be issued a 'Resource Added Event' as if this resource had been freshly created in the registry.
 
 ## Referential Integrity
 

--- a/docs/4.2. Behaviour - Querying.md
+++ b/docs/4.2. Behaviour - Querying.md
@@ -16,7 +16,7 @@ Where the behaviour associated with an API attribute is not sufficiently clear f
 
 ## Creating a WebSocket subscription
 
-In order to connect to a WebSocket, a client MUST first request a subscription of a particular type and with particular query parameters by performing a POST as defined in the [Query API](../APIs/QueryAPI.raml) subscriptions documentation. Use of GET requests to find existing suitable WebSocket connections is strongly discouraged.
+In order to connect to a WebSocket, a client MUST first request a subscription of a particular type and with particular query parameters by performing a `POST` as defined in the [Query API](../APIs/QueryAPI.raml) subscriptions documentation. Use of `GET` requests to find existing suitable WebSocket connections is strongly discouraged.
 
 There is no mandated URL base path for servers to use when creating WebSocket connections. Instead clients SHOULD observe the value of `ws_href` which is returned by their subscription request in order to identify what to connect to.
 
@@ -30,7 +30,7 @@ Long-lived connections to the Query API are supported via WebSockets which can b
 
 Upon receiving a request for a new subscription, the Query API SHOULD identify whether it already has any WebSockets open which provide for the requested query. If a WebSocket exists, the `subscription` object representing it MAY be returned to the user. If a relevant WebSocket does not exist a new one SHOULD be created.
 
-In normal operation, once a WebSocket has no more clients subscribed to it the Query API MAY automatically remove it and its corresponding HTTP-advertised subscription object. The Query API MUST NOT acknowledge HTTP DELETE requests for WebSockets running in this 'non-persistent' mode, instead issuing an HTTP 403 response.
+In normal operation, once a WebSocket has no more clients subscribed to it the Query API MAY automatically remove it and its corresponding HTTP-advertised subscription object. The Query API MUST NOT acknowledge HTTP `DELETE` requests for WebSockets running in this 'non-persistent' mode, instead issuing an HTTP 403 response.
 
 If a 'persistent' WebSocket has been requested by the client, this MUST NOT be cleaned up automatically by the Query API, even if all consuming clients have disconnected. The user MAY request closing of this socket by issuing an HTTP DELETE. If an HTTP DELETE is issued prior to all WebSocket connections being closed, they SHOULD be forcibly closed by the server.
 

--- a/docs/4.2. Behaviour - Querying.md
+++ b/docs/4.2. Behaviour - Querying.md
@@ -61,11 +61,11 @@ Event data containing only a `post` attribute signifies creation of a resource.
 ```json
 {
   "grain_type": "event",
-  "source_id": <id_of_query_api_instance>,
+  "source_id": "<id_of_query_api_instance>",
   "flow_id": "e223e6f3-de75-4855-bd19-b83774e31689",
-  "origin_timestamp": <ts_secs>:<ts_nsecs>,
-  "sync_timestamp": <ts_secs>:<ts_nsecs>,
-  "creation_timestamp": <ts_secs>:<ts_nsecs>,
+  "origin_timestamp": "<ts_secs>:<ts_nsecs>",
+  "sync_timestamp": "<ts_secs>:<ts_nsecs>",
+  "creation_timestamp": "<ts_secs>:<ts_nsecs>",
   "rate": {
     "numerator": 0,
     "denominator": 1
@@ -101,11 +101,11 @@ Event data containing only a `pre` attribute signifies deletion of a resource.
 ```json
 {
   "grain_type": "event",
-  "source_id": <id_of_query_service_instance>,
+  "source_id": "<id_of_query_service_instance>",
   "flow_id": "e223e6f3-de75-4855-bd19-b83774e31689",
-  "origin_timestamp": <ts_secs>:<ts_nsecs>,
-  "sync_timestamp": <ts_secs>:<ts_nsecs>,
-  "creation_timestamp": <ts_secs>:<ts_nsecs>,
+  "origin_timestamp": "<ts_secs>:<ts_nsecs>",
+  "sync_timestamp": "<ts_secs>:<ts_nsecs>",
+  "creation_timestamp": "<ts_secs>:<ts_nsecs>",
   "rate": {
     "numerator": 0,
     "denominator": 1
@@ -141,11 +141,11 @@ Event data containing both `pre` and `post` attributes signifies modification of
 ```json
 {
   "grain_type": "event",
-  "source_id": <id_of_query_service_instance>,
+  "source_id": "<id_of_query_service_instance>",
   "flow_id": "e223e6f3-de75-4855-bd19-b83774e31689",
-  "origin_timestamp": <ts_secs>:<ts_nsecs>,
-  "sync_timestamp": <ts_secs>:<ts_nsecs>,
-  "creation_timestamp": <ts_secs>:<ts_nsecs>,
+  "origin_timestamp": "<ts_secs>:<ts_nsecs>",
+  "sync_timestamp": "<ts_secs>:<ts_nsecs>",
+  "creation_timestamp": "<ts_secs>:<ts_nsecs>",
   "rate": {
     "numerator": 0,
     "denominator": 1
@@ -188,11 +188,11 @@ Event data containing both  `pre` and  `post` where the contents of  `pre` and  
 ```json
 {
   "grain_type": "event",
-  "source_id": <id_of_query_service_instance>,
+  "source_id": "<id_of_query_service_instance>",
   "flow_id": "e223e6f3-de75-4855-bd19-b83774e31689",
-  "origin_timestamp": <ts_secs>:<ts_nsecs>,
-  "sync_timestamp": <ts_secs>:<ts_nsecs>,
-  "creation_timestamp": <ts_secs>:<ts_nsecs>,
+  "origin_timestamp": "<ts_secs>:<ts_nsecs>",
+  "sync_timestamp": "<ts_secs>:<ts_nsecs>",
+  "creation_timestamp": "<ts_secs>:<ts_nsecs>",
   "rate": {
     "numerator": 0,
     "denominator": 1

--- a/docs/4.2. Behaviour - Querying.md
+++ b/docs/4.2. Behaviour - Querying.md
@@ -26,7 +26,7 @@ Connection upgrade procedures permitting an existing HTTP query to transition to
 
 ### Query API Behaviour
 
-Long-lived connections to the Query API are supported via WebSockets which can be set up via the `/subscriptions` resource. Query APIs MAY additionally support the HTTP `Upgrade` header sent by clients to upgrade an HTTP GET request to a WebSocket. In cases where this is performed, a corresponding entry in `/subscriptions` MUST also be created with matching query parameters.
+Long-lived connections to the Query API are supported via WebSockets which can be set up via the `/subscriptions` resource. Query APIs MAY additionally support the HTTP `Upgrade` header sent by clients to upgrade an HTTP `GET` request to a WebSocket. In cases where this is performed, a corresponding entry in `/subscriptions` MUST also be created with matching query parameters.
 
 Upon receiving a request for a new subscription, the Query API SHOULD identify whether it already has any WebSockets open which provide for the requested query. If a WebSocket exists, the `subscription` object representing it MAY be returned to the user. If a relevant WebSocket does not exist a new one SHOULD be created.
 

--- a/docs/4.3. Behaviour - Nodes.md
+++ b/docs/4.3. Behaviour - Nodes.md
@@ -8,7 +8,7 @@ Where the behaviour associated with an API attribute is not sufficiently clear f
 
 ### All Resources
 
-`caps`: Capabilities are intended to signal a collection of inputs or outputs which a given resource is able to consume or produce, but which it might not be doing at this instant. For example, Receiver capabilities indicate the types of data a Receiver can consume from a network. The specification defines capabilities of 'media\_types' and 'event\_types' for Receivers which take an array form. Future additions to capabilities and the structure which they use will be documented external to this specification.
+`caps`: Capabilities are intended to signal a collection of inputs or outputs which a given resource is able to consume or produce, but which it might not be doing at this instant. For example, Receiver capabilities indicate the types of data a Receiver can consume from a network. The specification defines capabilities of `media_types` and `event_types` for Receivers which take an array form. Future additions to capabilities and the structure which they use will be documented external to this specification.
 
 ### Sources & Flows
 
@@ -16,25 +16,25 @@ Core Source and Flow attributes are defined directly within this specification. 
 
 ### Senders
 
-`subscription`: The 'subscription' key is used to indicate how a Sender currently connects to Receivers in a networked media system. The subscription MUST be updated to reflect the current configuration of the Sender whether it was modified via an NMOS mechanism or an externally-defined control mechanism.
+`subscription`: The `subscription` key is used to indicate how a Sender currently connects to Receivers in a networked media system. The subscription MUST be updated to reflect the current configuration of the Sender whether it was modified via an NMOS mechanism or an externally-defined control mechanism.
 
-`subscription` `active`: The 'active' key MUST be set to 'true' when the Sender is configured to enable transmission of packets to the network, whether via a push- or pull-based mechanism. The key MUST be set to 'false' when the Sender is configured to disable transmission of packets to the network.
+`subscription` `active`: The `active` key MUST be set to `true` when the Sender is configured to enable transmission of packets to the network, whether via a push- or pull-based mechanism. The key MUST be set to `false` when the Sender is configured to disable transmission of packets to the network.
 
-`subscription` `receiver_id`: The 'receiver_id' key MUST be set to `null` in all cases except where a unicast push-based Sender is configured to transmit to an NMOS Receiver, and the 'active' key is set to 'true'. When not set to `null`, the 'receiver_id' MUST be set to the UUID of an NMOS Receiver.
+`subscription` `receiver_id`: The `receiver_id` key MUST be set to `null` in all cases except where a unicast push-based Sender is configured to transmit to an NMOS Receiver, and the `active` key is set to `true`. When not set to `null`, the `receiver_id` MUST be set to the UUID of an NMOS Receiver.
 
-`interface_bindings`: For push-based transports the Sender 'interface_bindings' SHOULD contain a single network interface unless a redundancy mechanism such as ST.2022-7 is in use, in which case each 'leg' SHOULD have its matching interface listed. Where the redundancy mechanism sends more than one copy of the stream via the same interface, that interface SHOULD be listed a corresponding number of times. For pull-based transports the Sender 'interface_bindings' SHOULD list each interface which the Sender is listening for connections on.
+`interface_bindings`: For push-based transports the Sender `interface_bindings` SHOULD contain a single network interface unless a redundancy mechanism such as ST.2022-7 is in use, in which case each 'leg' SHOULD have its matching interface listed. Where the redundancy mechanism sends more than one copy of the stream via the same interface, that interface SHOULD be listed a corresponding number of times. For pull-based transports the Sender `interface_bindings` SHOULD list each interface which the Sender is listening for connections on.
 
-`manifest_href`: The Sender 'manifest_href' SHOULD provide an HTTP(S) accessible URL to a file describing how to connect to the Sender (SDP in the case of RTP). The Sender's 'version' attribute SHOULD be updated if the contents of this file are modified. This URL MAY return an HTTP 404 where the 'active' parameter in the 'subscription' object is present and set to false (v1.2+ only). The value SHOULD be `null` when the transport type used by the Sender does not require a transport file.
+`manifest_href`: The Sender `manifest_href` SHOULD provide an HTTP(S) accessible URL to a file describing how to connect to the Sender (SDP in the case of RTP). The Sender's `version` attribute SHOULD be updated if the contents of this file are modified. This URL MAY return an HTTP 404 where the `active` parameter in the `subscription` object is present and set to false (v1.2+ only). The value SHOULD be `null` when the transport type used by the Sender does not require a transport file.
 
 ### Receivers
 
-`subscription`: The 'subscription' key is used to indicate how a Receiver currently connects to Senders in a networked media system. The subscription MUST be updated to reflect the current configuration of the Receiver whether it was modified via an NMOS mechanism or an externally-defined control mechanism.
+`subscription`: The `subscription` key is used to indicate how a Receiver currently connects to Senders in a networked media system. The subscription MUST be updated to reflect the current configuration of the Receiver whether it was modified via an NMOS mechanism or an externally-defined control mechanism.
 
-`subscription` `active`: The 'active' key MUST be set to 'true' when the Receiver is configured to enable reception of packets from the network. The key MUST be set to 'false' when the Receiver is configured to disable reception of packets from the network.
+`subscription` `active`: The `active` key MUST be set to `true` when the Receiver is configured to enable reception of packets from the network. The key MUST be set to `false` when the Receiver is configured to disable reception of packets from the network.
 
-`subscription` `sender_id`: The 'sender_id' key MUST be set to `null` in all cases except where the Receiver is currently configured to receive from an NMOS Sender, and the 'active' key is set to 'true'. When not set to `null`, the 'sender_id' MUST be set to the UUID of an NMOS Sender.
+`subscription` `sender_id`: The `sender_id` key MUST be set to `null` in all cases except where the Receiver is currently configured to receive from an NMOS Sender, and the `active` key is set to `true`. When not set to `null`, the `sender_id` MUST be set to the UUID of an NMOS Sender.
 
-`interface_bindings`: For push-based transports the Receiver 'interface_bindings' SHOULD contain a single network interface unless a redundancy mechanism such as ST.2022-7 is in use, in which case each 'leg' SHOULD have its matching interface listed. Where the redundancy mechanism receives more than one copy of the stream via the same interface, that interface SHOULD be listed a corresponding number of times. For push-based transports the Receiver 'interface_bindings' SHOULD list a single interface through which content is being consumed.
+`interface_bindings`: For push-based transports the Receiver `interface_bindings` SHOULD contain a single network interface unless a redundancy mechanism such as ST.2022-7 is in use, in which case each 'leg' SHOULD have its matching interface listed. Where the redundancy mechanism receives more than one copy of the stream via the same interface, that interface SHOULD be listed a corresponding number of times. For push-based transports the Receiver `interface_bindings` SHOULD list a single interface through which content is being consumed.
 
 ## Modifying Receiver Subscriptions
 
@@ -44,8 +44,8 @@ Please see the NMOS Connection API specification for the current methods for cre
 
 A PUT request to `/receivers/{receiverId}/target` of the Node API will modify which Sender a Receiver is subscribed to.
 
-In order to 'subscribe' a Receiver to a Sender, a PUT request SHOULD be made to this resource containing a full Sender object.
-In order to 'unsubscribe' a Receiver from a Sender, an empty object '{}' SHOULD be used in this PUT request.
+In order to subscribe a Receiver to a Sender, a PUT request SHOULD be made to this resource containing a full Sender object.
+In order to unsubscribe a Receiver from a Sender, an empty object `{}` SHOULD be used in this PUT request.
 In both cases the target resource SHOULD respond with a 202 code (accepted) on success, and a response body matching the request body.
 
-The Receiver's subscription object contains a 'sender_id' attribute which MUST be updated once a Receiver has successfully requested, parsed and actioned a change based on the Sender's transport file (SDP in the case of RTP).
+The Receiver's subscription object contains a `sender_id` attribute which MUST be updated once a Receiver has successfully requested, parsed and actioned a change based on the Sender's transport file (SDP in the case of RTP).

--- a/docs/4.3. Behaviour - Nodes.md
+++ b/docs/4.3. Behaviour - Nodes.md
@@ -24,7 +24,7 @@ Core Source and Flow attributes are defined directly within this specification. 
 
 `interface_bindings`: For push-based transports the Sender `interface_bindings` SHOULD contain a single network interface unless a redundancy mechanism such as ST 2022-7 is in use, in which case each 'leg' SHOULD have its matching interface listed. Where the redundancy mechanism sends more than one copy of the stream via the same interface, that interface SHOULD be listed a corresponding number of times. For pull-based transports the Sender `interface_bindings` SHOULD list each interface on which the Sender is listening for connections.
 
-`manifest_href`: The Sender `manifest_href` SHOULD provide an HTTP(S) accessible URL to a file describing how to connect to the Sender (SDP in the case of RTP). The Sender's `version` attribute SHOULD be updated if the contents of this file are modified. This URL MAY return an HTTP 404 where the `active` parameter in the `subscription` object is present and set to `false` (v1.2+ only). The value SHOULD be `null` when the transport type used by the Sender does not require a transport file.
+`manifest_href`: The Sender `manifest_href` SHOULD provide an HTTP(S) accessible URL to a file describing how to connect to the Sender (SDP in the case of RTP). The Sender's `version` attribute SHOULD be updated if the contents of this file are modified. This URL MAY return an HTTP 404 (Not Found) where the `active` parameter in the `subscription` object is present and set to `false` (v1.2+ only). The value SHOULD be `null` when the transport type used by the Sender does not require a transport file.
 
 ### Receivers
 
@@ -38,7 +38,7 @@ Core Source and Flow attributes are defined directly within this specification. 
 
 ## Modifying Receiver Subscriptions
 
-This method is deprecated, but SHOULD be supported alongside any other connection mechanisms up to and including v1.2. From v1.3 Nodes MAY choose to return a 501 response from this endpoint as opposed to implementing it.
+This method is deprecated, but SHOULD be supported alongside any other connection mechanisms up to and including v1.2. From v1.3 Nodes MAY choose to return a 501 (Not Implemented) response from this endpoint as opposed to implementing it.
 
 Please see the NMOS Connection API specification for the current methods for creating connections between Senders and Receivers.
 
@@ -46,6 +46,6 @@ A `PUT` request to `/receivers/{receiverId}/target` of the Node API will modify 
 
 In order to subscribe a Receiver to a Sender, a `PUT` request SHOULD be made to this resource containing a full Sender object.
 In order to unsubscribe a Receiver from a Sender, an empty object `{}` SHOULD be used in this `PUT` request.
-In both cases the target resource SHOULD respond with a 202 code (accepted) on success, and a response body matching the request body.
+In both cases the target resource SHOULD respond with a 202 (Accepted) code on success, and a response body matching the request body.
 
 The Receiver's subscription object contains a `sender_id` attribute which MUST be updated once a Receiver has successfully requested, parsed and actioned a change based on the Sender's transport file (SDP in the case of RTP).

--- a/docs/4.3. Behaviour - Nodes.md
+++ b/docs/4.3. Behaviour - Nodes.md
@@ -42,10 +42,10 @@ This method is deprecated, but SHOULD be supported alongside any other connectio
 
 Please see the NMOS Connection API specification for the current methods for creating connections between Senders and Receivers.
 
-A PUT request to `/receivers/{receiverId}/target` of the Node API will modify which Sender a Receiver is subscribed to.
+A `PUT` request to `/receivers/{receiverId}/target` of the Node API will modify which Sender a Receiver is subscribed to.
 
-In order to subscribe a Receiver to a Sender, a PUT request SHOULD be made to this resource containing a full Sender object.
-In order to unsubscribe a Receiver from a Sender, an empty object `{}` SHOULD be used in this PUT request.
+In order to subscribe a Receiver to a Sender, a `PUT` request SHOULD be made to this resource containing a full Sender object.
+In order to unsubscribe a Receiver from a Sender, an empty object `{}` SHOULD be used in this `PUT` request.
 In both cases the target resource SHOULD respond with a 202 code (accepted) on success, and a response body matching the request body.
 
 The Receiver's subscription object contains a `sender_id` attribute which MUST be updated once a Receiver has successfully requested, parsed and actioned a change based on the Sender's transport file (SDP in the case of RTP).

--- a/docs/4.3. Behaviour - Nodes.md
+++ b/docs/4.3. Behaviour - Nodes.md
@@ -22,9 +22,9 @@ Core Source and Flow attributes are defined directly within this specification. 
 
 `subscription` `receiver_id`: The `receiver_id` key MUST be set to `null` in all cases except where a unicast push-based Sender is configured to transmit to an NMOS Receiver, and the `active` key is set to `true`. When not set to `null`, the `receiver_id` MUST be set to the UUID of an NMOS Receiver.
 
-`interface_bindings`: For push-based transports the Sender `interface_bindings` SHOULD contain a single network interface unless a redundancy mechanism such as ST.2022-7 is in use, in which case each 'leg' SHOULD have its matching interface listed. Where the redundancy mechanism sends more than one copy of the stream via the same interface, that interface SHOULD be listed a corresponding number of times. For pull-based transports the Sender `interface_bindings` SHOULD list each interface which the Sender is listening for connections on.
+`interface_bindings`: For push-based transports the Sender `interface_bindings` SHOULD contain a single network interface unless a redundancy mechanism such as ST 2022-7 is in use, in which case each 'leg' SHOULD have its matching interface listed. Where the redundancy mechanism sends more than one copy of the stream via the same interface, that interface SHOULD be listed a corresponding number of times. For pull-based transports the Sender `interface_bindings` SHOULD list each interface on which the Sender is listening for connections.
 
-`manifest_href`: The Sender `manifest_href` SHOULD provide an HTTP(S) accessible URL to a file describing how to connect to the Sender (SDP in the case of RTP). The Sender's `version` attribute SHOULD be updated if the contents of this file are modified. This URL MAY return an HTTP 404 where the `active` parameter in the `subscription` object is present and set to false (v1.2+ only). The value SHOULD be `null` when the transport type used by the Sender does not require a transport file.
+`manifest_href`: The Sender `manifest_href` SHOULD provide an HTTP(S) accessible URL to a file describing how to connect to the Sender (SDP in the case of RTP). The Sender's `version` attribute SHOULD be updated if the contents of this file are modified. This URL MAY return an HTTP 404 where the `active` parameter in the `subscription` object is present and set to `false` (v1.2+ only). The value SHOULD be `null` when the transport type used by the Sender does not require a transport file.
 
 ### Receivers
 
@@ -34,7 +34,7 @@ Core Source and Flow attributes are defined directly within this specification. 
 
 `subscription` `sender_id`: The `sender_id` key MUST be set to `null` in all cases except where the Receiver is currently configured to receive from an NMOS Sender, and the `active` key is set to `true`. When not set to `null`, the `sender_id` MUST be set to the UUID of an NMOS Sender.
 
-`interface_bindings`: For push-based transports the Receiver `interface_bindings` SHOULD contain a single network interface unless a redundancy mechanism such as ST.2022-7 is in use, in which case each 'leg' SHOULD have its matching interface listed. Where the redundancy mechanism receives more than one copy of the stream via the same interface, that interface SHOULD be listed a corresponding number of times. For push-based transports the Receiver `interface_bindings` SHOULD list a single interface through which content is being consumed.
+`interface_bindings`: For push-based transports the Receiver `interface_bindings` SHOULD contain a single network interface unless a redundancy mechanism such as ST 2022-7 is in use, in which case each 'leg' SHOULD have its matching interface listed. Where the redundancy mechanism receives more than one copy of the stream via the same interface, that interface SHOULD be listed a corresponding number of times. For push-based transports the Receiver `interface_bindings` SHOULD list a single interface through which content is being consumed.
 
 ## Modifying Receiver Subscriptions
 

--- a/docs/5.1. Data Model - Identifier Mapping.md
+++ b/docs/5.1. Data Model - Identifier Mapping.md
@@ -126,7 +126,7 @@ It is suggested that Flow IDs be generated using the combination of:
 
 - The parent Source ID
 - A processing element type and index (or name) within the Device
-- A processing element Flow index (or name)\
+- A processing element Flow index (or name)
 - Parent Flow ID\*\*
 
     \*\*Only in cases where a new Flow ID is generated as the result of a 1:1 transformation (such as an encode) rather than a many-to-one transformation (such as a vision mix).

--- a/docs/5.1. Data Model - Identifier Mapping.md
+++ b/docs/5.1. Data Model - Identifier Mapping.md
@@ -22,7 +22,7 @@ All resources shown above are part of the JT-NM reference architecture. Each log
 
 A new Source is created in the following circumstances:
 
-- At the input of essence into a networked media enviroment from the 'edge' (ie. a legacy or incompatible protocol)
+- At the input of essence into a networked media enviroment from the 'edge' (i.e. a legacy or incompatible protocol)
 - At the point of capture (i.e. in a network connected camera or microphone)
 - At the mix point of two or more Flows of essence (i.e. an audio mix bus, vision mix bus)
 - Where a multiplexed Source is split into multiple mono-essence Sources

--- a/docs/5.1. Data Model - Identifier Mapping.md
+++ b/docs/5.1. Data Model - Identifier Mapping.md
@@ -23,25 +23,25 @@ All resources shown above are part of the JT-NM reference architecture. Each log
 A new Source is created in the following circumstances:
 
 - At the input of essence into a networked media enviroment from the 'edge' (ie. a legacy or incompatible protocol)
-- At the point of capture (ie. in a network connected camera or microphone)
-- At the mix point of two or more Flows of essence (ie. an audio mix bus, vision mix bus)
+- At the point of capture (i.e. in a network connected camera or microphone)
+- At the mix point of two or more Flows of essence (i.e. an audio mix bus, vision mix bus)
 - Where a multiplexed Source is split into multiple mono-essence Sources
 - Where a set of Flows are combined as a single multiplexed Source
 
-Whenever a new Source is generated, its immediate parent Source(s) MUST be recorded. This is achieved via a `parents` attribute in the Node API Sources resource. This contains an array of Source IDs corresponding to the Sources whose Flows have been brought together at this point. For example, a vision mixer which is fading between a Flow from Source A, and a Flow from Source B would indicate ["A", "B"\] in its `parents` attribute for the duration of this transition.
+Whenever a new Source is generated, its immediate parent Source(s) MUST be recorded. This is achieved via a `parents` attribute in the Node API Sources resource. This contains an array of Source IDs corresponding to the Sources whose Flows have been brought together at this point. For example, a vision mixer which is fading between a Flow from Source A, and a Flow from Source B would indicate `["<id of A>", "<id of B>"]` in its `parents` attribute for the duration of this transition.
 
 ### Flows
 
 A new Flow is created in the following circumstances:
 
 - Where a Flow passes through a processing element which is modelled as a new Source
-- Where a Flow is modified in a non-editorial manner (ie. audio volume changed, EQ applied, video contrast changed, video encoded or decoded)
+- Where a Flow is modified in a non-editorial manner (i.e. audio volume changed, EQ applied, video contrast changed, video encoded or decoded)
 
 Note that in order to avoid creating a new Flow after every single processing element held within a Device, processing blocks can be logically grouped together provided it will never be possible to use a Flow from part way through the processing block. For example, a three band EQ block within an audio mixer will cause a new Flow to be generated. Creating a new Flow after each EQ band is an option, but as these Flows could never be used directly anywhere else internal or external to the Device the representation of it is of no benefit. It is however important to register the EQ process as a whole as a new Flow as it might be possible to route the pre-EQ and post-EQ essence to a Sender, or to a mixing element within the Device.
 
 Sources and Flows MUST be advertised via a Node's API, and registered via the Registration API if available. This SHOULD only be done on the Device which originates the Source or Flow; if a Flow is received by a Device from the network it does not need to be re-advertised via APIs.
 
-Whenever a new Flow is generated, its immediate parent Flow(s) MUST be recorded. This is achieved via a `parents` attribute in the Node API Flows resource. This contains an array of Flow IDs corresponding to the Flows which have been brought together at this point. For example, an encoder which codes a raw video Flow C into a coded video Flow D would indicate `["C"]` in its `parents` attribute.
+Whenever a new Flow is generated, its immediate parent Flow(s) MUST be recorded. This is achieved via a `parents` attribute in the Node API Flows resource. This contains an array of Flow IDs corresponding to the Flows which have been brought together at this point. For example, an encoder which codes a raw video Flow C into a coded video Flow D would indicate `["<id of C>"]` in its `parents` attribute.
 
 **Important Note:** A processing element which has a 1:1 input to output relationship and doesn't make editorial changes only need create a new Flow ID on output and not a new Source ID. As a Flow ID descends from a single consistent Source ID, the Flow ID for these processing elements MUST be generated based on seed data including the incoming Flow ID. If this dynamic Flow generation cannot be achieved, the processing element MUST be viewed as a new Source instead (see Flow ID section below).
 

--- a/docs/5.1. Data Model - Identifier Mapping.md
+++ b/docs/5.1. Data Model - Identifier Mapping.md
@@ -220,8 +220,7 @@ Input
 
 Output
 
-- Flow ID generated based on input Flow ID (see *Source and Flow
-    Representation* above)
+- Flow ID generated based on input Flow ID (see *Source and Flow Representation* above)
 - Fixed Sender ID
 
 ### Processing Device: Hardware Audio Mixer

--- a/docs/5.1. Data Model - Identifier Mapping.md
+++ b/docs/5.1. Data Model - Identifier Mapping.md
@@ -41,7 +41,7 @@ Note that in order to avoid creating a new Flow after every single processing el
 
 Sources and Flows MUST be advertised via a Node's API, and registered via the Registration API if available. This SHOULD only be done on the Device which originates the Source or Flow; if a Flow is received by a Device from the network it does not need to be re-advertised via APIs.
 
-Whenever a new Flow is generated, its immediate parent Flow(s) MUST be recorded. This is achieved via a `parents` attribute in the Node API Flows resource. This contains an array of Flow IDs corresponding to the Flows which have been brought together at this point. For example, an encoder which codes a raw video Flow C into a coded video Flow D would indicate ["C"] in its `parents` attribute.
+Whenever a new Flow is generated, its immediate parent Flow(s) MUST be recorded. This is achieved via a `parents` attribute in the Node API Flows resource. This contains an array of Flow IDs corresponding to the Flows which have been brought together at this point. For example, an encoder which codes a raw video Flow C into a coded video Flow D would indicate `["C"]` in its `parents` attribute.
 
 **Important Note:** A processing element which has a 1:1 input to output relationship and doesn't make editorial changes only need create a new Flow ID on output and not a new Source ID. As a Flow ID descends from a single consistent Source ID, the Flow ID for these processing elements MUST be generated based on seed data including the incoming Flow ID. If this dynamic Flow generation cannot be achieved, the processing element MUST be viewed as a new Source instead (see Flow ID section below).
 

--- a/docs/5.1. Data Model - Identifier Mapping.md
+++ b/docs/5.1. Data Model - Identifier Mapping.md
@@ -22,26 +22,26 @@ All resources shown above are part of the JT-NM reference architecture. Each log
 
 A new Source is created in the following circumstances:
 
--   At the input of essence into a networked media enviroment from the 'edge' (ie. a legacy or incompatible protocol)
--   At the point of capture (ie. in a network connected camera or microphone)
--   At the mix point of two or more Flows of essence (ie. an audio mix bus, vision mix bus)
--   Where a multiplexed Source is split into multiple mono-essence Sources
--   Where a set of Flows are combined as a single multiplexed Source
+- At the input of essence into a networked media enviroment from the 'edge' (ie. a legacy or incompatible protocol)
+- At the point of capture (ie. in a network connected camera or microphone)
+- At the mix point of two or more Flows of essence (ie. an audio mix bus, vision mix bus)
+- Where a multiplexed Source is split into multiple mono-essence Sources
+- Where a set of Flows are combined as a single multiplexed Source
 
-Whenever a new Source is generated, its immediate parent Source(s) MUST be recorded. This is achieved via a 'parents' attribute in the Node API Sources resource. This contains an array of Source IDs corresponding to the Sources whose Flows have been brought together at this point. For example, a vision mixer which is fading between a Flow from Source A, and a Flow from Source B would indicate \["A", "B"\] in its 'parents' attribute for the duration of this transition.
+Whenever a new Source is generated, its immediate parent Source(s) MUST be recorded. This is achieved via a `parents` attribute in the Node API Sources resource. This contains an array of Source IDs corresponding to the Sources whose Flows have been brought together at this point. For example, a vision mixer which is fading between a Flow from Source A, and a Flow from Source B would indicate ["A", "B"\] in its `parents` attribute for the duration of this transition.
 
 ### Flows
 
 A new Flow is created in the following circumstances:
 
--   Where a Flow passes through a processing element which is modelled as a new Source
--   Where a Flow is modified in a non-editorial manner (ie. audio volume changed, EQ applied, video contrast changed, video encoded or decoded)
+- Where a Flow passes through a processing element which is modelled as a new Source
+- Where a Flow is modified in a non-editorial manner (ie. audio volume changed, EQ applied, video contrast changed, video encoded or decoded)
 
 Note that in order to avoid creating a new Flow after every single processing element held within a Device, processing blocks can be logically grouped together provided it will never be possible to use a Flow from part way through the processing block. For example, a three band EQ block within an audio mixer will cause a new Flow to be generated. Creating a new Flow after each EQ band is an option, but as these Flows could never be used directly anywhere else internal or external to the Device the representation of it is of no benefit. It is however important to register the EQ process as a whole as a new Flow as it might be possible to route the pre-EQ and post-EQ essence to a Sender, or to a mixing element within the Device.
 
 Sources and Flows MUST be advertised via a Node's API, and registered via the Registration API if available. This SHOULD only be done on the Device which originates the Source or Flow; if a Flow is received by a Device from the network it does not need to be re-advertised via APIs.
 
-Whenever a new Flow is generated, its immediate parent Flow(s) MUST be recorded. This is achieved via a 'parents' attribute in the Node API Flows resource. This contains an array of Flow IDs corresponding to the Flows which have been brought together at this point. For example, an encoder which codes a raw video Flow C into a coded video Flow D would indicate \["C"\] in its 'parents' attribute.
+Whenever a new Flow is generated, its immediate parent Flow(s) MUST be recorded. This is achieved via a `parents` attribute in the Node API Flows resource. This contains an array of Flow IDs corresponding to the Flows which have been brought together at this point. For example, an encoder which codes a raw video Flow C into a coded video Flow D would indicate ["C"] in its `parents` attribute.
 
 **Important Note:** A processing element which has a 1:1 input to output relationship and doesn't make editorial changes only need create a new Flow ID on output and not a new Source ID. As a Flow ID descends from a single consistent Source ID, the Flow ID for these processing elements MUST be generated based on seed data including the incoming Flow ID. If this dynamic Flow generation cannot be achieved, the processing element MUST be viewed as a new Source instead (see Flow ID section below).
 
@@ -57,9 +57,9 @@ For physical Nodes, the Node ID MUST be universally unique to that Node, and rem
 
 For virtual Nodes, the Node ID MUST be universally unique to that Node. If a snapshot is taken of a virtual Node and the snapshot re-deployed:
 
--   If re-deploying via the same controller which created it and no other instantiation of this virtual Node exists, the original Node ID SHOULD be used.
--   If re-deploying via the same controller which created it and an instantiation of this virtual Node exists, it MUST be deployed with a new ID. Uses of this Node ID (and child resources) in any other stored data MUST be mapped to the new ID during this process.
--   If re-deploying via a different controller and it cannot be guaranteed that another instance of this virtual Node does not already exist, a new Node ID MUST be generated, with any stored data being mapped to the new ID during the process.
+- If re-deploying via the same controller which created it and no other instantiation of this virtual Node exists, the original Node ID SHOULD be used.
+- If re-deploying via the same controller which created it and an instantiation of this virtual Node exists, it MUST be deployed with a new ID. Uses of this Node ID (and child resources) in any other stored data MUST be mapped to the new ID during this process.
+- If re-deploying via a different controller and it cannot be guaranteed that another instance of this virtual Node does not already exist, a new Node ID MUST be generated, with any stored data being mapped to the new ID during the process.
 
 To simplify the above for deploying snapshots, each instantiation of a virtual Node snapshop MAY have a new Node ID. In such a case, a mapping MUST be provided to translate between old and new IDs so that session / production / automation data remain relevant.
 
@@ -67,67 +67,67 @@ To simplify the above for deploying snapshots, each instantiation of a virtual N
 
 Owned by:
 
--   Node ID
+- Node ID
 
 SHOULD change if:
 
--   The same Device configuration operates on a different Node
--   A duplicate of the Device operates at the same time as the original instantiation
+- The same Device configuration operates on a different Node
+- A duplicate of the Device operates at the same time as the original instantiation
 
 SHOULD NOT change if:
 
--   The same Device configuration is re-loaded onto the same Node after a reboot or similar
+- The same Device configuration is re-loaded onto the same Node after a reboot or similar
 
 It is suggested that Device IDs be generated using the combination of:
 
--   The parent Node ID
--   A Device serial number if available in the case of physical systems, or a persistent identifier or index created upon Device instantiation in the case of virtual systems
+- The parent Node ID
+- A Device serial number if available in the case of physical systems, or a persistent identifier or index created upon Device instantiation in the case of virtual systems
 
 ### Source ID
 
 Owned by:
 
--   Device ID
+- Device ID
 
 SHOULD change if:
 
--   Device ID changes
--   A different physical interface (such as an SDI input) is used to retrieve essence
--   Format URN changes between video, audio, data and mux variants
+- Device ID changes
+- A different physical interface (such as an SDI input) is used to retrieve essence
+- Format URN changes between `video`, `audio`, `data` and `mux` variants
 
 SHOULD NOT change if:
 
--   Configuration parameters associated with the Source are changed, such as its operating resolution or bitrate
--   Labels, descriptions or other metadata associated with the Source resource are modified
+- Configuration parameters associated with the Source are changed, such as its operating resolution or bitrate
+- Labels, descriptions or other metadata associated with the Source resource are modified
 
 It is suggested that Source IDs be generated using a combination of:
 
--   The parent Device ID
--   A processing element type and index (or name) within the Device
--   A processing element Source index (or name)
+- The parent Device ID
+- A processing element type and index (or name) within the Device
+- A processing element Source index (or name)
 
 ### Flow ID
 
 Owned by:
 
--   Source ID
+- Source ID
 
 SHOULD Change if:
 
--   Source ID changes
--   Format URN changes between video, audio, data and mux variants (including between two codec types)
+- Source ID changes
+- Format URN changes between `video`, `audio`, `data` and `mux` variants (including between two codec types)
 
 SHOULD NOT change if:
 
--   Configuration parameters associated with the Flow are changed, such as its operating resolution or bitrate
--   Labels, descriptions or other metadata associated with the Flow resource are modified
+- Configuration parameters associated with the Flow are changed, such as its operating resolution or bitrate
+- Labels, descriptions or other metadata associated with the Flow resource are modified
 
 It is suggested that Flow IDs be generated using the combination of:
 
--   The parent Source ID
--   A processing element type and index (or name) within the Device
--   A processing element Flow index (or name)\
--   Parent Flow ID\*\*
+- The parent Source ID
+- A processing element type and index (or name) within the Device
+- A processing element Flow index (or name)\
+- Parent Flow ID\*\*
 
     \*\*Only in cases where a new Flow ID is generated as the result of a 1:1 transformation (such as an encode) rather than a many-to-one transformation (such as a vision mix).
 
@@ -135,45 +135,44 @@ It is suggested that Flow IDs be generated using the combination of:
 
 Owned by:
 
--   Device ID
+- Device ID
 
 SHOULD change if:
 
--   Device ID changes
--   Transport type URN changes
+- Device ID changes
+- Transport type URN changes
 
 SHOULD NOT change if:
 
--   Flow ID it is sending changes
--   A virtual Device is re-configured, adding or removing some Senders, but keeping this one
+- Flow ID it is sending changes
+- A virtual Device is re-configured, adding or removing some Senders, but keeping this one
 
 It is suggested that Sender IDs be generated using the combination of:
 
--   The parent Device ID
--   An output connection identifier such as a bus name, index or similar
+- The parent Device ID
+- An output connection identifier such as a bus name, index or similar
 
 ### Receiver ID
 
 Owned by:
 
--   Device ID
+- Device ID
 
 SHOULD change if:
 
--   Device ID changes
--   Transport type URN changes
--   Supported data format URN changes between video, audio, data and mux (including between two codec types)
+- Device ID changes
+- Transport type URN changes
+- Supported data format URN changes between `video`, `audio`, `data` and `mux` (including between two codec types)
 
 SHOULD NOT change if:
 
--   Sender ID it is receiving from changes
--   A virtual Device is re-configured, adding or removing some Receivers, but keeping this one
+- Sender ID it is receiving from changes
+- A virtual Device is re-configured, adding or removing some Receivers, but keeping this one
 
 It is suggested that Receiver IDs be generated using the combination of:
 
--   The parent Device ID
--   An input connection identifier such as a channel name, index or similar
-
+- The parent Device ID
+- An input connection identifier such as a channel name, index or similar
 
 ## Virtual Identifiers
 
@@ -192,18 +191,18 @@ These examples demonstrate how to apply identity to Devices in real world applic
 
 System
 
--   Fixed Node ID
--   Fixed Device ID
+- Fixed Node ID
+- Fixed Device ID
 
 Input
 
--   SDI or Camera Sensor
+- SDI or Camera Sensor
 
 Output
 
--   Fixed Source IDs
--   Fixed Flow IDs
--   Fixed Sender IDs
+- Fixed Source IDs
+- Fixed Flow IDs
+- Fixed Sender IDs
 
 ### Processing Device: Hardware IP Codec
 
@@ -212,18 +211,18 @@ Output
 
 System
 
--   Fixed Node ID
--   Fixed Device ID
+- Fixed Node ID
+- Fixed Device ID
 
 Input
 
--   Fixed Receiver ID
+- Fixed Receiver ID
 
 Output
 
--   Flow ID generated based on input Flow ID (see *Source and Flow
+- Flow ID generated based on input Flow ID (see *Source and Flow
     Representation* above)
--   Fixed Sender ID
+- Fixed Sender ID
 
 ### Processing Device: Hardware Audio Mixer
 
@@ -234,33 +233,33 @@ NB: A new Flow is created following each processing element where a tap off coul
 
 System
 
--   Fixed Node ID
--   Fixed Device ID
+- Fixed Node ID
+- Fixed Device ID
 
 Channel Strip
 
--   Fixed Receiver ID
--   Input dependent Flow ID following each self-contained processing element (see *Source and Flow Representation* above)
+- Fixed Receiver ID
+- Input dependent Flow ID following each self-contained processing element (see *Source and Flow Representation* above)
 
 Tone Generator
 
--   Fixed Source ID
--   Fixed Flow ID
+- Fixed Source ID
+- Fixed Flow ID
 
 Delay Line
 
--   Output Source and Flow ID match input
+- Output Source and Flow ID match input
 
 PGM Bus
 
--   Fixed Source ID and Flow ID
--   Fixed Sender ID
+- Fixed Source ID and Flow ID
+- Fixed Sender ID
 
 Monitor Bus
 
--   Fixed Source ID
--   Fixed Flow ID
--   Fixed Sender ID
+- Fixed Source ID
+- Fixed Flow ID
+- Fixed Sender ID
 
 During operation, as with any other fixed hardware Device there is little need to generate new identifiers as they can be baked into the Device at manufacture. Changes will however be needed to the ancestry recorded against Flows and Sources within the API (and network registry if applicable). These changes will occur whenever a modification is made to bus routing, such as pressing a PFL button or linking a channel to a particular group.
 
@@ -285,30 +284,30 @@ Having built a vision mixer from the palette above, a simple example layout is s
 
 System
 
--   Fixed Node ID
+- Fixed Node ID
 
--   Fixed Device ID
+- Fixed Device ID
 
     NB: This assumes the mixer cannot be logically split into two distinct mixers. In this case multiple Device IDs might exist.
 
 Inputs
 
--   Fixed Receiver ID pool, or generated based on seed data of Device ID
+- Fixed Receiver ID pool, or generated based on seed data of Device ID
     and Receiver index
 
 Outputs
 
--   Fixed Sender ID pool, or generated based on seed data of Device ID
+- Fixed Sender ID pool, or generated based on seed data of Device ID
     and Sender index
 
 Pattern Generator
 
--   Source and Flow ID generated based on seed data of Device ID, processor type and pattern generator index within Device
+- Source and Flow ID generated based on seed data of Device ID, processor type and pattern generator index within Device
 
     Alternatively these IDs could be statically associated with a processor from the palette, rather than assigning them upon instantiation
 
 FX Keyer
 
--   Source and Flow ID generated based on seed data of Device ID, processor type and FX keyer index within the Device
+- Source and Flow ID generated based on seed data of Device ID, processor type and FX keyer index within the Device
 
     Alternatively these IDs could be statically associated with a processor from the palette, rather than assigning them upon instantiation

--- a/docs/6.0. Upgrade Path.md
+++ b/docs/6.0. Upgrade Path.md
@@ -32,7 +32,7 @@ Nodes which support multiple versions simultaneously MUST ensure that all of the
 
 ### v1.3 to v1.2
 
-- Nodes: `attached_network_device` (in `interfaces`), `authorization` (in api endpoints), `authorization` (in `services`)
+- Nodes: `attached_network_device` (in `interfaces`), `authorization` (in `api` `endpoints`), `authorization` (in `services`)
 - Devices: `authorization` (in `controls`)
 - Sources: `event_type`
 - Flows: `event_type`
@@ -61,10 +61,10 @@ It is strongly RECOMMENDED to match Query API client compatibility to the maximu
 ### Affected Keys From v1.3
 
 - Devices: `type` could be listed as any new variant of `urn:x-nmos:device`
-- Flows: `transfer_characteristic` could be listed as any string to permit future -ensibility
+- Flows: `transfer_characteristic` could be listed as any string to permit future extensibility
 - Flows: `colorspace` could be listed as any string to permit future extensibility
 - Senders: `transport` could be listed as any new variant of `urn:x-nmos:transport`
-- Senders: `manifest_href` could be listed as `null` for transport types that do - require a transport file
+- Senders: `manifest_href` could be listed as `null` for transport types that do not require a transport file
 - Receivers: `transport` could be listed as any new variant of `urn:x-nmos:transport`
 
 ### Affected Keys From v1.2
@@ -82,7 +82,7 @@ No keys are affected
 The following procedure is suggested for a live system which needs to migrate between API versions. This guide assumes that the registry and key clients support the Query API downgrade feature.
 
 - Upgrade the Query API(s) to support serving the new version of responses, whilst providing backwards compatibility to old versions active in the running system.
-- Upgrade Query API clients which support the ?query.downgrade parameter and as such can still access all data in the system. Check ahead of doing this that the Query API server implementation supports the downgrade feature.
+- Upgrade Query API clients which support the `query.downgrade` parameter and as such can still access all data in the system. Check ahead of doing this that the Query API server implementation supports the downgrade feature.
 - Upgrade the registry and Registration API(s) to support registrations using the new version, whilst continuing to support registrations at the old version.
 - Upgrade Nodes in the system to register against the new API version. Any Nodes which also interact with the Query API will continue to query using the old version initially unless they support downgrade queries.
 - Once all relevant Nodes have been upgraded, all Query API clients can be upgraded or instructed to perform queries against the new version.

--- a/docs/6.0. Upgrade Path.md
+++ b/docs/6.0. Upgrade Path.md
@@ -20,7 +20,7 @@ Implementers of the Registration and Query API MUST support at least one API ver
 
 When supporting multiple API versions, Query APIs MUST provide translations of resources for backwards compatibility (see [Version Translations](#version-translations)). For example, if the registry contains a mixture of v1.0 and v1.1 resources, a v1.0 Query API needs to to provide a response containing all of these resources by removing keys from v1.1 resources which are not present in v1.0. Translations MUST NOT be provided for `/subscriptions` endpoints, which only expose subscriptions matching the endpoint's API version.
 
-Query APIs do not need to provide for forwards compatibility as it might be impossible to generate data for new attributes in schemas. Query APIs SHOULD however allow clients to request older data than the requested minor API version by using the `?query.downgrade=<version>` query parameter (see Query API documentation for examples).
+Query APIs do not need to provide for forwards compatibility as it might be impossible to generate data for new attributes in schemas. Query APIs SHOULD however allow clients to request older data than the requested minor API version by using the `query.downgrade=<version>` query parameter (see Query API documentation for examples).
 
 ### Version Translations
 

--- a/docs/6.0. Upgrade Path.md
+++ b/docs/6.0. Upgrade Path.md
@@ -24,7 +24,7 @@ Query APIs do not need to provide for forwards compatibility as it might be impo
 
 ### Version Translations
 
-When conforming a resource to an earlier API version, Query API implementations SHOULD make best efforts to remove attributes which were not references in earlier versions' schemas. The core attributes which fall into this category are documented here for clarity, but the same data could be derived from analysis of the schema changes between API versions. Implementers need to be aware that in the future new attributes can be defined externally to this specification. 
+When conforming a resource to an earlier API version, Query API implementations SHOULD make best efforts to remove attributes which were not references in earlier versions' schemas. The core attributes which fall into this category are documented here for clarity, but the same data could be derived from analysis of the schema changes between API versions. Implementers need to be aware that in the future new attributes can be defined externally to this specification.
 
 Note that removal of these keys does not guarantee conformance to the schema of the earlier API version due to the addition of new `enum` values and similar features in more recent API versions. As such, Query APIs SHOULD NOT validate translated resources against schemas.
 
@@ -32,23 +32,23 @@ Nodes which support multiple versions simultaneously MUST ensure that all of the
 
 ### v1.3 to v1.2
 
-*   Nodes: `attached_network_device` (in `interfaces`), `authorization` (in `api` `endpoints`), `authorization` (in `services`)
-*   Devices: `authorization` (in `controls`)
-*   Sources: `event_type`
-*   Flows: `event_type`
+- Nodes: `attached_network_device` (in `interfaces`), `authorization` (in api endpoints), `authorization` (in `services`)
+- Devices: `authorization` (in `controls`)
+- Sources: `event_type`
+- Flows: `event_type`
 
 ### v1.2 to v1.1
 
-*   Nodes: `interfaces`
-*   Senders: `caps`, `interface_bindings`, `subscription`
-*   Receivers: `interface_bindings`, `active` (in `subscription`)
+- Nodes: `interfaces`
+- Senders: `caps`, `interface_bindings`, `subscription`
+- Receivers: `interface_bindings`, `active` (in `subscription`)
 
 ### v1.1 to v1.0
 
-*   Nodes: `api`, `clocks`, `description`, `tags`
-*   Devices: `controls`, `description`, `tags`
-*   Sources: `channels`, `clock_name`, `grain_rate`
-*   Flows: `bit_depth`, `colorspace`, `components`, `device_id`, `DID_SDID`, `frame_height`, `frame_width`, `grain_rate`, `interlace_mode`, `media_type`, `sample_rate`, `transfer_characteristic`
+- Nodes: `api`, `clocks`, `description`, `tags`
+- Devices: `controls`, `description`, `tags`
+- Sources: `channels`, `clock_name`, `grain_rate`
+- Flows: `bit_depth`, `colorspace`, `components`, `device_id`, `DID_SDID`, `frame_height`, `frame_width`, `grain_rate`, `interlace_mode`, `media_type`, `sample_rate`, `transfer_characteristic`
 
 ## Requirements for Query API Clients
 

--- a/docs/6.0. Upgrade Path.md
+++ b/docs/6.0. Upgrade Path.md
@@ -8,47 +8,47 @@ API versioning is specified in the [APIs](2.0.%20APIs.md) documentation, with pr
 
 ## Requirements for Nodes (Node APIs)
 
-Node API implementations MUST support at least one API version, and MAY support more than one at a time. Note however that a Node MUST only perform interactions with a Registration API at a single version. Nodes implementing multiple API versions MAY provide a user-configurable choice for which API version to register and/or query using. Otherwise it is expected that the Node will select a Registration API which supports the highest API version which the Node also supports. The API version SHOULD be selected before considering the Registration API's configured \'priority\'.
+Node API implementations MUST support at least one API version, and MAY support more than one at a time. Note however that a Node MUST only perform interactions with a Registration API at a single version. Nodes implementing multiple API versions MAY provide a user-configurable choice for which API version to register and/or query using. Otherwise it is expected that the Node will select a Registration API which supports the highest API version which the Node also supports. The API version SHOULD be selected before considering the Registration API's configured `priority`.
 
 Registrations MUST NOT proceed if the Node API version implemented does not exactly match the API version used by the Registration API.
 
-Where a Node implements version v1.2 or below, it MUST browse for both the \'\_nmos-register.\_tcp\' DNS-SD service type, and the legacy \'\_nmos-registration.\_tcp\' DNS-SD service type in order to retrieve the full list of available Registration APIs. De-duplication SHOULD be performed against this returned list.
+Where a Node implements version v1.2 or below, it MUST browse for both the `_nmos-register._tcp` DNS-SD service type, and the legacy `_nmos-registration._tcp` DNS-SD service type in order to retrieve the full list of available Registration APIs. De-duplication SHOULD be performed against this returned list.
 
 ## Requirements for Registries (Registration and Query APIs)
 
 Implementers of the Registration and Query API MUST support at least one API version. It is however strongly RECOMMENDED that Registration and Query APIs fully support at least two and preferably more consecutive API versions (if released). In doing so, facilities which include a large number of Nodes can stagger their equipment upgrades whilst maintaining compatibility with a single registry.
 
-When supporting multiple API versions, Query APIs MUST provide translations of resources for backwards compatibility (see [Version Translations](#version-translations)). For example, if the registry contains a mixture of v1.0 and v1.1 resources, a v1.0 Query API needs to to provide a response containing all of these resources by removing keys from v1.1 resources which are not present in v1.0. Translations MUST NOT be provided for '/subscriptions' endpoints, which only expose subscriptions matching the endpoint's API version.
+When supporting multiple API versions, Query APIs MUST provide translations of resources for backwards compatibility (see [Version Translations](#version-translations)). For example, if the registry contains a mixture of v1.0 and v1.1 resources, a v1.0 Query API needs to to provide a response containing all of these resources by removing keys from v1.1 resources which are not present in v1.0. Translations MUST NOT be provided for `/subscriptions` endpoints, which only expose subscriptions matching the endpoint's API version.
 
-Query APIs do not need to provide for forwards compatibility as it might be impossible to generate data for new attributes in schemas. Query APIs SHOULD however allow clients to request older data than the requested minor API version by using the ?query.downgrade=<version> query parameter (see Query API documentation for examples).
+Query APIs do not need to provide for forwards compatibility as it might be impossible to generate data for new attributes in schemas. Query APIs SHOULD however allow clients to request older data than the requested minor API version by using the `?query.downgrade=<version>` query parameter (see Query API documentation for examples).
 
 ### Version Translations
 
 When conforming a resource to an earlier API version, Query API implementations SHOULD make best efforts to remove attributes which were not references in earlier versions' schemas. The core attributes which fall into this category are documented here for clarity, but the same data could be derived from analysis of the schema changes between API versions. Implementers need to be aware that in the future new attributes can be defined externally to this specification. 
 
-Note that removal of these keys does not guarantee conformance to the schema of the earlier API version due to the addition of new 'enum' values and similar features in more recent API versions. As such, Query APIs SHOULD NOT validate translated resources against schemas.
+Note that removal of these keys does not guarantee conformance to the schema of the earlier API version due to the addition of new `enum` values and similar features in more recent API versions. As such, Query APIs SHOULD NOT validate translated resources against schemas.
 
 Nodes which support multiple versions simultaneously MUST ensure that all of their resources meet the schemas for each corresponding version of the specification which is supported. Where necessary features are only available in the most recent version(s) of the specification it could be necessary to expose only a limited subset of a Node's resources from lower versioned endpoints.
 
 ### v1.3 to v1.2
 
-*   Nodes: 'attached_network_device' (in 'interfaces'), 'authorization' (in 'api' 'endpoints'), 'authorization' (in 'services')
-*   Devices: 'authorization' (in 'controls')
-*   Sources: 'event_type'
-*   Flows: 'event_type'
+*   Nodes: `attached_network_device` (in `interfaces`), `authorization` (in `api` `endpoints`), `authorization` (in `services`)
+*   Devices: `authorization` (in `controls`)
+*   Sources: `event_type`
+*   Flows: `event_type`
 
 ### v1.2 to v1.1
 
-*   Nodes: 'interfaces'
-*   Senders: 'caps', 'interface_bindings', 'subscription'
-*   Receivers: 'interface_bindings', 'active' (in 'subscription')
+*   Nodes: `interfaces`
+*   Senders: `caps`, `interface_bindings`, `subscription`
+*   Receivers: `interface_bindings`, `active` (in `subscription`)
 
 ### v1.1 to v1.0
 
-*   Nodes: 'api', 'clocks', 'description', 'tags'
-*   Devices: 'controls', 'description', 'tags'
-*   Sources: 'channels', 'clock_name', 'grain_rate'
-*   Flows: 'bit_depth', 'colorspace', 'components', 'device_id', 'DID_SDID', 'frame_height', 'frame_width', 'grain_rate', 'interlace_mode', 'media_type', 'sample_rate', 'transfer_characteristic'
+*   Nodes: `api`, `clocks`, `description`, `tags`
+*   Devices: `controls`, `description`, `tags`
+*   Sources: `channels`, `clock_name`, `grain_rate`
+*   Flows: `bit_depth`, `colorspace`, `components`, `device_id`, `DID_SDID`, `frame_height`, `frame_width`, `grain_rate`, `interlace_mode`, `media_type`, `sample_rate`, `transfer_characteristic`
 
 ## Requirements for Query API Clients
 
@@ -60,12 +60,12 @@ It is strongly RECOMMENDED to match Query API client compatibility to the maximu
 
 ### Affected Keys From v1.3
 
-*   Devices: 'type' could be listed as any new variant of 'urn:x-nmos:device'
-*   Flows: 'transfer_characteristic' could be listed as any string to permit future extensibility
-*   Flows: 'colorspace' could be listed as any string to permit future extensibility
-*   Senders: 'transport' could be listed as any new variant of 'urn:x-nmos:transport'
-*   Senders: 'manifest_href' could be listed as `null` for transport types that do not require a transport file
-*   Receivers: 'transport' could be listed as any new variant of 'urn:x-nmos:transport'
+- Devices: `type` could be listed as any new variant of `urn:x-nmos:device`
+- Flows: `transfer_characteristic` could be listed as any string to permit future -ensibility
+- Flows: `colorspace` could be listed as any string to permit future extensibility
+- Senders: `transport` could be listed as any new variant of `urn:x-nmos:transport`
+- Senders: `manifest_href` could be listed as `null` for transport types that do - require a transport file
+- Receivers: `transport` could be listed as any new variant of `urn:x-nmos:transport`
 
 ### Affected Keys From v1.2
 
@@ -73,16 +73,16 @@ No keys are affected
 
 ### Affected Keys From v1.1
 
-*   Sources: 'format' could be listed as 'urn:x-nmos:format:mux'
-*   Flows: 'format' could be listed as 'urn:x-nmos:format:mux'
-*   Senders: 'flow_id' could be listed as `null`
+- Sources: `format` could be listed as `urn:x-nmos:format:mux`
+- Flows: `format` could be listed as `urn:x-nmos:format:mux`
+- Senders: `flow_id` could be listed as `null`
 
 ## Performing Upgrades
 
 The following procedure is suggested for a live system which needs to migrate between API versions. This guide assumes that the registry and key clients support the Query API downgrade feature.
 
-* Upgrade the Query API(s) to support serving the new version of responses, whilst providing backwards compatibility to old versions active in the running system.
-* Upgrade Query API clients which support the ?query.downgrade parameter and as such can still access all data in the system. Check ahead of doing this that the Query API server implementation supports the downgrade feature.
-* Upgrade the registry and Registration API(s) to support registrations using the new version, whilst continuing to support registrations at the old version.
-* Upgrade Nodes in the system to register against the new API version. Any Nodes which also interact with the Query API will continue to query using the old version initially unless they support downgrade queries.
-* Once all relevant Nodes have been upgraded, all Query API clients can be upgraded or instructed to perform queries against the new version.
+- Upgrade the Query API(s) to support serving the new version of responses, whilst providing backwards compatibility to old versions active in the running system.
+- Upgrade Query API clients which support the ?query.downgrade parameter and as such can still access all data in the system. Check ahead of doing this that the Query API server implementation supports the downgrade feature.
+- Upgrade the registry and Registration API(s) to support registrations using the new version, whilst continuing to support registrations at the old version.
+- Upgrade Nodes in the system to register against the new API version. Any Nodes which also interact with the Query API will continue to query using the old version initially unless they support downgrade queries.
+- Once all relevant Nodes have been upgraded, all Query API clients can be upgraded or instructed to perform queries against the new version.


### PR DESCRIPTION
Currently these use 'quotes' for URLs, parameter names etc, but more recent NMOS specs have used `backticks` for monospace rendering., This is consistent how examples and other codeblocks appear and look better.

This should be merged (if we choose to do it) before merging docs-language. Or is it `docs-language`?