### PR TITLE
example.api.com -> api.example.com

### DIFF
--- a/APIs/NodeAPI.raml
+++ b/APIs/NodeAPI.raml
@@ -4,7 +4,7 @@
 # (c) AMWA 2016
 
 title: Node
-baseUri: http://example.api.com/x-nmos/node/{version}
+baseUri: http://api.example.com/x-nmos/node/{version}
 version: v1.3
 mediaType: application/json
 types:

--- a/APIs/QueryAPI.raml
+++ b/APIs/QueryAPI.raml
@@ -4,7 +4,7 @@
 # (c) AMWA 2016
 
 title: Query
-baseUri: http://example.api.com/x-nmos/query/{version}
+baseUri: http://api.example.com/x-nmos/query/{version}
 version: v1.3
 mediaType: application/json
 types:
@@ -47,7 +47,7 @@ traits:
           Link:
             description: Provides references to cursors for paging. The 'rel' attribute may be one of 'next', 'prev', 'first' or 'last'
             type: string
-            example: <http://example.api.com/x-nmos/query/{version}/nodes/?paging.since=1441716120:318744030&paging.limit=20>; rel="next", <http://example.api.com/x-nmos/query/{version}/nodes/?paging.until=1441716353:6839634&paging.limit=20>; rel="prev"
+            example: <http://api.example.com/x-nmos/query/{version}/nodes/?paging.since=1441716120:318744030&paging.limit=20>; rel="next", <http://api.example.com/x-nmos/query/{version}/nodes/?paging.until=1441716353:6839634&paging.limit=20>; rel="prev"
           X-Paging-Limit:
             description: Identifies the current limit being used for paging. This may not match the requested value if the requested value was too high for the implementation
             type: integer

--- a/APIs/RegistrationAPI.raml
+++ b/APIs/RegistrationAPI.raml
@@ -4,7 +4,7 @@
 # (c) AMWA 2016
 
 title: Registration
-baseUri: http://example.api.com/x-nmos/registration/{version}
+baseUri: http://api.example.com/x-nmos/registration/{version}
 version: v1.3
 mediaType: application/json
 types:

--- a/docs/2.5. APIs - Query Parameters.md
+++ b/docs/2.5. APIs - Query Parameters.md
@@ -62,7 +62,7 @@ GET /x-nmos/query/v1.1/nodes
 Headers
 
 ```http
-Link: <http://example.api.com/x-nmos/query/v1.1/nodes/?paging.since=0:20&paging.limit=10>; rel="next", <http://example.api.com/x-nmos/query/v1.1/nodes/?paging.until=0:10&paging.limit=10>; rel="prev"
+Link: <http://api.example.com/x-nmos/query/v1.1/nodes/?paging.since=0:20&paging.limit=10>; rel="next", <http://api.example.com/x-nmos/query/v1.1/nodes/?paging.until=0:10&paging.limit=10>; rel="prev"
 X-Paging-Limit: 10
 X-Paging-Since: 0:10
 X-Paging-Until: 0:20
@@ -114,7 +114,7 @@ GET /x-nmos/query/v1.1/nodes?paging.limit=5
 Headers
 
 ```http
-Link: <http://example.api.com/x-nmos/query/v1.1/nodes/?paging.since=0:20&paging.limit=5>; rel="next", <http://example.api.com/x-nmos/query/v1.1/nodes/?paging.until=0:15&paging.limit=5>; rel="prev"
+Link: <http://api.example.com/x-nmos/query/v1.1/nodes/?paging.since=0:20&paging.limit=5>; rel="next", <http://api.example.com/x-nmos/query/v1.1/nodes/?paging.until=0:15&paging.limit=5>; rel="prev"
 X-Paging-Limit: 5
 X-Paging-Since: 0:15
 X-Paging-Until: 0:20
@@ -149,7 +149,7 @@ GET /x-nmos/query/v1.1/nodes?paging.since=0:4
 Headers
 
 ```http
-Link: <http://example.api.com/x-nmos/query/v1.1/nodes/?paging.since=0:14&paging.limit=10>; rel="next", <http://example.api.com/x-nmos/query/v1.1/nodes/?paging.until=0:4&paging.limit=10>; rel="prev"
+Link: <http://api.example.com/x-nmos/query/v1.1/nodes/?paging.since=0:14&paging.limit=10>; rel="next", <http://api.example.com/x-nmos/query/v1.1/nodes/?paging.until=0:4&paging.limit=10>; rel="prev"
 X-Paging-Limit: 10
 X-Paging-Since: 0:4
 X-Paging-Until: 0:14
@@ -185,7 +185,7 @@ GET /x-nmos/query/v1.1/nodes?paging.until=0:16
 Headers
 
 ```http
-Link: <http://example.api.com/x-nmos/query/v1.1/nodes/?paging.since=0:16&paging.limit=10>; rel="next", <http://example.api.com/x-nmos/query/v1.1/nodes/?paging.until=0:6&paging.limit=10>; rel="prev"
+Link: <http://api.example.com/x-nmos/query/v1.1/nodes/?paging.since=0:16&paging.limit=10>; rel="next", <http://api.example.com/x-nmos/query/v1.1/nodes/?paging.until=0:6&paging.limit=10>; rel="prev"
 X-Paging-Limit: 10
 X-Paging-Since: 0:6
 X-Paging-Until: 0:16
@@ -221,7 +221,7 @@ GET /x-nmos/query/v1.1/nodes?paging.since=0:4&paging.until=0:16
 Headers
 
 ```http
-Link: <http://example.api.com/x-nmos/query/v1.1/nodes/?paging.since=0:14&paging.limit=10>; rel="next", <http://example.api.com/x-nmos/query/v1.1/nodes/?paging.until=0:4&paging.limit=10>; rel="prev"
+Link: <http://api.example.com/x-nmos/query/v1.1/nodes/?paging.since=0:14&paging.limit=10>; rel="next", <http://api.example.com/x-nmos/query/v1.1/nodes/?paging.until=0:4&paging.limit=10>; rel="prev"
 X-Paging-Limit: 10
 X-Paging-Since: 0:4
 X-Paging-Until: 0:14
@@ -269,7 +269,7 @@ In this case, assume that there are stored records for `0:21` and `0:22` but no 
 Headers
 
 ```http
-Link: <http://example.api.com/x-nmos/query/v1.1/nodes/?paging.since=0:20&paging.limit=10>; rel="next", <http://example.api.com/x-nmos/query/v1.1/nodes/?paging.until=0:0&paging.limit=10>; rel="prev"
+Link: <http://api.example.com/x-nmos/query/v1.1/nodes/?paging.since=0:20&paging.limit=10>; rel="next", <http://api.example.com/x-nmos/query/v1.1/nodes/?paging.until=0:0&paging.limit=10>; rel="prev"
 X-Paging-Limit: 10
 X-Paging-Since: 0:0
 X-Paging-Until: 0:20
@@ -296,7 +296,7 @@ In this case, assume that there are stored records for `0:19` and `0:20` but no 
 Headers
 
 ```http
-Link: <http://example.api.com/x-nmos/query/v1.1/nodes/?paging.since=0:20&paging.limit=10>; rel="next", <http://example.api.com/x-nmos/query/v1.1/nodes/?paging.until=0:20&paging.limit=10>; rel="prev"
+Link: <http://api.example.com/x-nmos/query/v1.1/nodes/?paging.since=0:20&paging.limit=10>; rel="next", <http://api.example.com/x-nmos/query/v1.1/nodes/?paging.until=0:20&paging.limit=10>; rel="prev"
 X-Paging-Limit: 10
 X-Paging-Since: 0:20
 X-Paging-Until: 0:20
@@ -327,7 +327,7 @@ In this case, assume that the most recently created or updated Node held in the 
 Headers
 
 ```http
-Link: <http://example.api.com/x-nmos/query/v1.1/nodes/?label=My%20Node&paging.since=0:20&paging.limit=10>; rel="next", <http://example.api.com/x-nmos/query/v1.1/nodes/?label=My%20Node&paging.until=0:0&paging.limit=10>; rel="prev"
+Link: <http://api.example.com/x-nmos/query/v1.1/nodes/?label=My%20Node&paging.since=0:20&paging.limit=10>; rel="next", <http://api.example.com/x-nmos/query/v1.1/nodes/?label=My%20Node&paging.until=0:0&paging.limit=10>; rel="prev"
 X-Paging-Limit: 10
 X-Paging-Since: 0:0
 X-Paging-Until: 0:20
@@ -356,7 +356,7 @@ In this case, assume that the most recently created or updated Node held in the 
 Headers
 
 ```http
-Link: <http://example.api.com/x-nmos/query/v1.1/nodes/?label=My%20Invalid%20Node&paging.since=0:20&paging.limit=10>; rel="next", <http://example.api.com/x-nmos/query/v1.1/nodes/?label=My%20Invalid%20Node&paging.until=0:0&paging.limit=10>; rel="prev"
+Link: <http://api.example.com/x-nmos/query/v1.1/nodes/?label=My%20Invalid%20Node&paging.since=0:20&paging.limit=10>; rel="next", <http://api.example.com/x-nmos/query/v1.1/nodes/?label=My%20Invalid%20Node&paging.until=0:0&paging.limit=10>; rel="prev"
 X-Paging-Limit: 10
 X-Paging-Since: 0:0
 X-Paging-Until: 0:20


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc2606#section-3, https://tools.ietf.org/html/rfc6761#section-6.5

IS-08, IS-09, IS-10, etc. already get this right. I suggest we make this change in IS-04 v1.3.1, IS-05 v1.1.1, and next editorial releases of other specs. (I'll also make a PR for AMWA-TV/nmos-template.)