### PR TITLE
Add POST request examples for Subscriptions with query parameters

### DIFF
--- a/docs/4.2. Behaviour - Querying.md
+++ b/docs/4.2. Behaviour - Querying.md
@@ -24,6 +24,8 @@ In order to connect to a WebSocket, a client first requests a Subscription of a 
 
 Upon receiving a request for a new Subscription, the Query API MAY return an existing Subscription to the user, if it matches the requested attributes. If a relevant Subscription does not exist, a new one SHOULD be created.
 
+As for the HTTP API endpoints, a `501` (Not Implemented) HTTP status indicates that the requested query parameters are not supported by this Query API.
+
 There is no mandated URL base path for servers to use to provide WebSocket connections. Instead clients SHOULD observe the value of `ws_href` which is returned by their Subscription request in order to identify what to connect to.
 
 Query APIs MAY additionally support the HTTP protocol upgrade mechanism on list resources such as `/nodes` to transition an HTTP `GET` request to a WebSocket connection, but this is not mandated. In cases where this is performed, a corresponding entry in `/subscriptions` for a non-persistent Subscription MUST also be created with matching attributes.
@@ -209,7 +211,35 @@ Event data containing both  `pre` and  `post` where the contents of  `pre` and  
 
 #### Handling Query Parameters
 
-WebSocket subscriptions support query parameters in the same way as the corresponding HTTP API endpoints. Subscriptions MUST inform clients when resources begin to match, or no longer match, a given query parameter. For example:
+WebSocket subscriptions support query parameters in a similar way as the corresponding HTTP API endpoints. Query parameters are specified in a `params` attribute rather than the query string.
+The [Basic Queries](2.5.%20APIs%20-%20Query%20Parameters.md#basic-queries) documentation includes the examples:
+
+```http
+GET /x-nmos/query/v1.0/sources?format=urn:x-nmos:format:video&device_id=9126cc2f-4c26-4c9b-a6cd-93c4381c9be5
+```
+
+```http
+GET /x-nmos/query/v1.0/flows?tags.studio=HQ1
+```
+
+The `POST` requests to create equivalent Subscriptions would have:
+
+```json
+  "resource_path": "/sources",
+  "params": {
+    "format": "urn:x-nmos:format:video",
+    "device_id": "9126cc2f-4c26-4c9b-a6cd-93c4381c9be5"
+  }
+```
+
+```json
+  "resource_path": "/flows",
+  "params": {
+    "tags.studio": "HQ1"
+  }
+```
+
+Subscriptions MUST inform clients when resources begin to match, or no longer match, the given query parameters. For example:
 
 - If a Flow (or other resource) has a `tag` removed causing it to no longer match the query parameters for a WebSocket subscription, the client MUST be issued a 'Resource Removed Event' as if this resource had been deleted from the registry.
 - If a Flow (or other resource) has a `tag` added causing it to match a query parameter where it didn't match them previously, the client MUST be issued a 'Resource Added Event' as if this resource had been freshly created in the registry.


### PR DESCRIPTION
Resolves #122. There's more that could be said (e.g. about `query.rql`, and to make clear that e.g. `paging.order` makes no sense) but at this stage, this may be enough.