### PR TITLE
Clarify Sender's "subscription" usage in unicast

### DIFF
--- a/APIs/schemas/receiver_core.json
+++ b/APIs/schemas/receiver_core.json
@@ -42,19 +42,19 @@
           }
         },
         "subscription": {
-          "description": "Object containing the 'sender_id' currently subscribed to.",
+          "description": "Object indicating how this Receiver is currently configured to receive data.",
           "type": "object",
           "required": ["sender_id", "active"],
           "properties": {
             "sender_id": {
               "type": ["string", "null"],
-              "description": "UUID of the Sender that this Receiver is currently subscribed to",
+              "description": "UUID of the Sender from which this Receiver is currently configured to receive data, if it is active and receiving from an NMOS Sender, otherwise null",
               "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
               "default": null
             },
             "active": {
               "type": "boolean",
-              "description": "Receiver is enabled and configured with a Sender's connection parameters",
+              "description": "Receiver is enabled and configured to receive data",
               "default": false
             }
           }

--- a/APIs/schemas/receiver_core.json
+++ b/APIs/schemas/receiver_core.json
@@ -48,7 +48,7 @@
           "properties": {
             "sender_id": {
               "type": ["string", "null"],
-              "description": "UUID of the Sender from which this Receiver is currently configured to receive data, if it is active and receiving from an NMOS Sender, otherwise null",
+              "description": "UUID of the Sender from which this Receiver is currently configured to receive data. Only set if it is active and receiving from an NMOS Sender; otherwise null.",
               "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
               "default": null
             },

--- a/APIs/schemas/sender.json
+++ b/APIs/schemas/sender.json
@@ -61,13 +61,13 @@
           }
         },
         "subscription": {
-          "description": "Object containing the 'receiver_id' currently subscribed to (unicast only).",
+          "description": "Object containing the 'receiver_id' currently subscribed to.",
           "type": "object",
           "required": ["receiver_id", "active"],
           "properties": {
             "receiver_id": {
               "type": ["string", "null"],
-              "description": "UUID of the Receiver that this Sender is currently subscribed to",
+              "description": "UUID of the Receiver that this Sender is currently subscribed to (unicast only)",
               "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
               "default": null
             },

--- a/APIs/schemas/sender.json
+++ b/APIs/schemas/sender.json
@@ -67,7 +67,7 @@
           "properties": {
             "receiver_id": {
               "type": ["string", "null"],
-              "description": "UUID of the Receiver to which this Sender is currently configured to send data, if it is active, uses a unicast push-based transport and is sending to an NMOS Receiver, otherwise null",
+              "description": "UUID of the Receiver to which this Sender is currently configured to send data. Only set if it is active, uses a unicast push-based transport and is sending to an NMOS Receiver; otherwise null.",
               "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
               "default": null
             },

--- a/APIs/schemas/sender.json
+++ b/APIs/schemas/sender.json
@@ -61,13 +61,13 @@
           }
         },
         "subscription": {
-          "description": "Object containing the 'receiver_id' currently subscribed to.",
+          "description": "Object indicating how this Sender is currently configured to send data.",
           "type": "object",
           "required": ["receiver_id", "active"],
           "properties": {
             "receiver_id": {
               "type": ["string", "null"],
-              "description": "UUID of the Receiver that this Sender is currently subscribed to (unicast only)",
+              "description": "UUID of the Receiver to which this Sender is currently configured to send data, if it is active, uses a unicast push-based transport and is sending to an NMOS Receiver, otherwise null",
               "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
               "default": null
             },


### PR DESCRIPTION
It fixes an issue described in #170.